### PR TITLE
[CHORE] Add code coverage reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath "org.jacoco:org.jacoco.core:0.8.7"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/imx-android-sdk/build.gradle
+++ b/imx-android-sdk/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'maven-publish'
     id "org.jlleitschuh.gradle.ktlint" version "10.2.1"
     id "io.gitlab.arturbosch.detekt" version "1.20.0-RC1"
+    id 'jacoco'
 }
 
 def getArtifactId = { ->
@@ -31,6 +32,15 @@ android {
         consumerProguardFiles "consumer-rules.pro"
     }
 
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
+        }
+        unitTests.returnDefaultValues = true
+    }
+
     buildTypes {
         debug {
             debuggable true
@@ -55,7 +65,7 @@ android {
         outputDir = "$buildDir/generated".toString()
         apiPackage = "com.immutable.sdk.api"
         invokerPackage = "com.immutable.sdk.invoker"
-        modelPackage = "com.immutable.sdk.model"
+        modelPackage = "com.immutable.sdk.api.model"
         configOptions = [
                 dateLibrary: "java8"
         ]
@@ -144,3 +154,109 @@ detekt {
     allRules = false // activate all available (even unstable) rules.
     config = files("../.github/detekt/config/detekt.yml") // point to your custom config defining rules to run, overwriting default behavior
 }
+
+// Start code coverage
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+// Without this block the build will fail
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
+}
+
+// Creates a task for generating the jacoco coverage report
+project.afterEvaluate {
+    (android.hasProperty('applicationVariants')
+            ? android.'applicationVariants'
+            : android.'libraryVariants')
+            .all { variant ->
+                def variantName = variant.name
+                def unitTestTask = "test${variantName.capitalize()}UnitTest"
+
+                tasks.create(name: "${unitTestTask}Coverage", type: JacocoReport, dependsOn: [
+                        "$unitTestTask",
+                ]) {
+                    group = "Reporting"
+                    description = "Generate Jacoco coverage reports for the ${variantName.capitalize()} build"
+
+                    reports {
+                        html.required = true
+                        xml.required = true
+                    }
+
+                    def excludes = [
+                            // data binding
+                            'android/databinding/**/*.class',
+                            '**/android/databinding/*Binding.class',
+                            '**/android/databinding/*',
+                            '**/androidx/databinding/*',
+                            '**/BR.*',
+                            // android
+                            '**/R.class',
+                            '**/R$*.class',
+                            '**/BuildConfig.*',
+                            '**/Manifest*.*',
+                            '**/*Test*.*',
+                            'android/**/*.*',
+                            // kotlin
+                            '**/*MapperImpl*.*',
+                            '**/*$ViewInjector*.*',
+                            '**/*$ViewBinder*.*',
+                            '**/BuildConfig.*',
+                            '**/*Component*.*',
+                            '**/*BR*.*',
+                            '**/Manifest*.*',
+                            '**/*$Lambda$*.*',
+                            '**/*Companion*.*',
+                            '**/*Module*.*',
+                            '**/*Dagger*.*',
+                            '**/*Hilt*.*',
+                            '**/*MembersInjector*.*',
+                            '**/*_MembersInjector.class',
+                            '**/*_Factory*.*',
+                            '**/*_Provide*Factory*.*',
+                            '**/*Extensions*.*',
+                            // sealed and data classes
+                            '**/*$Result.*',
+                            '**/*$Result$*.*',
+                            '/com/immutable/sdk/api/**',
+                            '/org/openapitools/**',
+                    ]
+
+                    def javaClasses = fileTree(dir: variant.javaCompileProvider.get().destinationDir,
+                            excludes: excludes)
+                    def kotlinClasses = fileTree(dir: "${buildDir}/tmp/kotlin-classes/${variantName}",
+                            excludes: excludes)
+
+                    classDirectories.setFrom(files([
+                            javaClasses,
+                            kotlinClasses
+                    ]))
+
+                    def variantSourceSets = variant.sourceSets.java.srcDirs.collect { it.path }.flatten()
+                    sourceDirectories.setFrom(project.files(variantSourceSets))
+
+                    def androidTestsData = fileTree(dir: "${buildDir}/outputs/code_coverage/${variantName}AndroidTest/connected/", includes: ["**/*.ec"])
+
+                    executionData(files([
+                            "$project.buildDir/jacoco/${unitTestTask}.exec",
+                            androidTestsData
+                    ]))
+                }
+
+            }
+}
+
+// Kotlin 1.5+ only works with version 0.8.7
+configurations.all{
+    resolutionStrategy {
+        eachDependency { details ->
+            if ('org.jacoco' == details.requested.group) {
+                details.useVersion "0.8.7"
+            }
+        }
+    }
+}
+// End code coverage

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/extensions/Token.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/extensions/Token.kt
@@ -1,7 +1,7 @@
 package com.immutable.sdk.extensions
 
-import com.immutable.sdk.model.Token
-import com.immutable.sdk.model.TokenData
+import com.immutable.sdk.api.model.Token
+import com.immutable.sdk.api.model.TokenData
 import com.immutable.sdk.utils.TokenType
 
 /**

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/model/AssetModel.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/model/AssetModel.kt
@@ -1,5 +1,7 @@
 package com.immutable.sdk.model
 
+import com.immutable.sdk.api.model.Token
+
 /**
  * @param quantity the amount of the asset to be transferred/sold/bought
  */

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/model/Erc20Asset.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/model/Erc20Asset.kt
@@ -1,5 +1,7 @@
 package com.immutable.sdk.model
 
+import com.immutable.sdk.api.model.Token
+import com.immutable.sdk.api.model.TokenData
 import com.immutable.sdk.utils.TokenType
 
 class Erc20Asset(

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/model/Erc721Asset.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/model/Erc721Asset.kt
@@ -1,5 +1,7 @@
 package com.immutable.sdk.model
 
+import com.immutable.sdk.api.model.Token
+import com.immutable.sdk.api.model.TokenData
 import com.immutable.sdk.utils.Constants.ERC721_AMOUNT
 import com.immutable.sdk.utils.TokenType
 

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/model/EthAsset.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/model/EthAsset.kt
@@ -1,5 +1,7 @@
 package com.immutable.sdk.model
 
+import com.immutable.sdk.api.model.Token
+import com.immutable.sdk.api.model.TokenData
 import com.immutable.sdk.utils.Constants
 import com.immutable.sdk.utils.TokenType
 

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/BuyWorkflow.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/BuyWorkflow.kt
@@ -6,9 +6,9 @@ import com.immutable.sdk.StarkSigner
 import com.immutable.sdk.api.OrdersApi
 import com.immutable.sdk.api.TradesApi
 import com.immutable.sdk.extensions.clean
-import com.immutable.sdk.model.CreateTradeRequest
-import com.immutable.sdk.model.GetSignableOrderRequest
-import com.immutable.sdk.model.GetSignableOrderResponse
+import com.immutable.sdk.api.model.CreateTradeRequest
+import com.immutable.sdk.api.model.GetSignableOrderRequest
+import com.immutable.sdk.api.model.GetSignableOrderResponse
 import com.immutable.sdk.model.OrderStatus
 import java.util.concurrent.CompletableFuture
 

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/CancelWorkflow.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/CancelWorkflow.kt
@@ -4,7 +4,7 @@ import com.immutable.sdk.ImmutableException
 import com.immutable.sdk.StarkSigner
 import com.immutable.sdk.api.OrdersApi
 import com.immutable.sdk.crypto.CryptoUtil
-import com.immutable.sdk.model.CancelOrderRequest
+import com.immutable.sdk.api.model.CancelOrderRequest
 import java.util.concurrent.CompletableFuture
 
 private const val CANCEL_ORDER = "Cancel order"

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/LoginWorkflow.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/LoginWorkflow.kt
@@ -8,7 +8,7 @@ import com.immutable.sdk.crypto.CryptoUtil
 import com.immutable.sdk.extensions.hexToByteArray
 import com.immutable.sdk.extensions.sanitizeBytes
 import com.immutable.sdk.extensions.toHexString
-import com.immutable.sdk.model.RegisterUserRequestVerifyEth
+import com.immutable.sdk.api.model.RegisterUserRequestVerifyEth
 import com.immutable.sdk.stark.StarkCurve
 import com.immutable.sdk.stark.StarkKey
 import com.immutable.sdk.utils.Constants

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/SellWorkflow.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/SellWorkflow.kt
@@ -5,7 +5,9 @@ import com.immutable.sdk.ImmutableException
 import com.immutable.sdk.Signer
 import com.immutable.sdk.StarkSigner
 import com.immutable.sdk.api.OrdersApi
-import com.immutable.sdk.model.*
+import com.immutable.sdk.api.model.*
+import com.immutable.sdk.model.Erc721Asset
+import com.immutable.sdk.model.SellToken
 import com.immutable.sdk.utils.Constants
 import com.immutable.sdk.utils.TokenType
 import java.math.BigDecimal

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/TransferWorkflow.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/TransferWorkflow.kt
@@ -3,7 +3,11 @@ package com.immutable.sdk.workflows
 import com.immutable.sdk.Signer
 import com.immutable.sdk.StarkSigner
 import com.immutable.sdk.api.TransfersApi
-import com.immutable.sdk.model.*
+import com.immutable.sdk.api.model.CreateTransferRequest
+import com.immutable.sdk.api.model.CreateTransferResponse
+import com.immutable.sdk.api.model.GetSignableTransferRequest
+import com.immutable.sdk.api.model.GetSignableTransferResponse
+import com.immutable.sdk.model.AssetModel
 import java.util.concurrent.CompletableFuture
 
 internal fun transfer(

--- a/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/Workflow.kt
+++ b/imx-android-sdk/src/main/java/com/immutable/sdk/workflows/Workflow.kt
@@ -3,7 +3,7 @@ package com.immutable.sdk.workflows
 import com.immutable.sdk.ImmutableException
 import com.immutable.sdk.StarkSigner
 import com.immutable.sdk.crypto.CryptoUtil
-import com.immutable.sdk.model.GetSignableOrderResponse
+import com.immutable.sdk.api.model.GetSignableOrderResponse
 import java.util.concurrent.CompletableFuture
 
 private const val SIGNABLE_ORDER = "Signable order"

--- a/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/BuyWorkflowTest.kt
+++ b/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/BuyWorkflowTest.kt
@@ -3,7 +3,7 @@ package com.immutable.sdk.workflows
 import com.immutable.sdk.*
 import com.immutable.sdk.api.OrdersApi
 import com.immutable.sdk.api.TradesApi
-import com.immutable.sdk.model.*
+import com.immutable.sdk.api.model.*
 import com.immutable.sdk.utils.TokenType
 import io.mockk.MockKAnnotations
 import io.mockk.every

--- a/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/CancelWorkflowTest.kt
+++ b/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/CancelWorkflowTest.kt
@@ -4,7 +4,7 @@ import com.immutable.sdk.ImmutableException
 import com.immutable.sdk.StarkSigner
 import com.immutable.sdk.TestException
 import com.immutable.sdk.api.OrdersApi
-import com.immutable.sdk.model.CancelOrderResponse
+import com.immutable.sdk.api.model.CancelOrderResponse
 import com.immutable.sdk.testFuture
 import io.mockk.MockKAnnotations
 import io.mockk.every

--- a/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/LoginWorkflowTest.kt
+++ b/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/LoginWorkflowTest.kt
@@ -4,8 +4,8 @@ import com.immutable.sdk.ImmutableException
 import com.immutable.sdk.Signer
 import com.immutable.sdk.TestException
 import com.immutable.sdk.api.UsersApi
-import com.immutable.sdk.model.GetUsersApiResponse
-import com.immutable.sdk.model.RegisterUserResponse
+import com.immutable.sdk.api.model.GetUsersApiResponse
+import com.immutable.sdk.api.model.RegisterUserResponse
 import com.immutable.sdk.testFuture
 import com.immutable.sdk.utils.Constants
 import io.mockk.MockKAnnotations

--- a/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/SellWorkflowTest.kt
+++ b/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/SellWorkflowTest.kt
@@ -2,9 +2,9 @@ package com.immutable.sdk.workflows
 
 import com.immutable.sdk.*
 import com.immutable.sdk.api.OrdersApi
-import com.immutable.sdk.model.CreateOrderResponse
+import com.immutable.sdk.api.model.CreateOrderResponse
 import com.immutable.sdk.model.Erc721Asset
-import com.immutable.sdk.model.GetSignableOrderResponse
+import com.immutable.sdk.api.model.GetSignableOrderResponse
 import com.immutable.sdk.model.SellToken
 import io.mockk.MockKAnnotations
 import io.mockk.every

--- a/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/TransferWorkflowTest.kt
+++ b/imx-android-sdk/src/test/java/com/immutable/sdk/workflows/TransferWorkflowTest.kt
@@ -4,7 +4,10 @@ import com.immutable.sdk.Signer
 import com.immutable.sdk.StarkSigner
 import com.immutable.sdk.TestException
 import com.immutable.sdk.api.TransfersApi
-import com.immutable.sdk.model.*
+import com.immutable.sdk.api.model.*
+import com.immutable.sdk.model.Erc20Asset
+import com.immutable.sdk.model.Erc721Asset
+import com.immutable.sdk.model.EthAsset
 import com.immutable.sdk.testFuture
 import io.mockk.MockKAnnotations
 import io.mockk.every


### PR DESCRIPTION
Refactored generated api models package from `com.immutable.sdk.model` to `com.immutable.sdk.api.model` so it can be easily excluded and doesn't clash with our mapping models.

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/5234460/163082287-83ab069a-1dcd-4b60-8195-10fc784113f3.png">
