### PR TITLE
[FEAT] Include source and javadocs JAR when publishing library

### DIFF
--- a/imx-core-sdk-android/build.gradle
+++ b/imx-core-sdk-android/build.gradle
@@ -14,7 +14,7 @@ def getArtifactId = { ->
 }
 
 def getVersionName = { ->
-    return "0.0.19"
+    return "0.0.3"
 }
 
 task addHeader(type: Exec) {
@@ -33,9 +33,15 @@ task cleanDocs() {
 android {
     compileSdk 32
 
+    namespace = "com.immutable.sdk"
+
     defaultConfig {
         minSdk 27
         targetSdk 32
+
+        aarMetadata {
+            minCompileSdk = 27
+        }
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -91,6 +97,13 @@ android {
         }
     }
 
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
+
     // Generate all apis before every build
     preBuild.dependsOn(tasks.openApiGenerate)
 
@@ -126,18 +139,21 @@ dependencies {
 }
 
 def githubProperties = new Properties()
-def githubPropertiesFile = file("github.properties")
+def githubPropertiesFile = file("../github.properties")
 if (githubPropertiesFile.exists()) {
     githubProperties.load(new FileInputStream(githubPropertiesFile))
 }
 
 publishing {
     publications {
-        bar(MavenPublication) {
+        release(MavenPublication) {
             groupId 'com.immutable.sdk' // Replace with group ID
             artifactId getArtifactId()
             version getVersionName()
-            artifact("$buildDir/outputs/aar/${getArtifactId()}-release.aar")
+
+            afterEvaluate {
+                from components.release
+            }
         }
     }
 

--- a/imx-core-sdk-android/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -50,7 +50,7 @@ open class ApiClient(val baseUrl: String) {
             builder.addInterceptor {
 				it.proceed(
 					it.request().newBuilder()
-						.addHeader("x-sdk-version", "imx-core-sdk-android-0.0.19")
+						.addHeader("x-sdk-version", "imx-core-sdk-android-0.0.3")
 						.build()
 				)
 			}.build()


### PR DESCRIPTION
(As part of prepping the library for release)

Include Javadocs and source code in the published AAR so developers can read the source code of the Core SDK instead of seeing "compiled code".

This currently works for non `*Kt.class` files only.