### PR TITLE
Improve error logging

### DIFF
--- a/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -4,8 +4,6 @@ package {{apiPackage}}
 {{#imports}}import {{import}}
 {{/imports}}
 
-import org.json.JSONObject
-
 {{^doNotUseRxAndCoroutines}}
 {{#useCoroutines}}
 import kotlinx.coroutines.Dispatchers
@@ -65,18 +63,12 @@ import {{packageName}}.infrastructure.toMultiValue
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -4,6 +4,8 @@ package {{apiPackage}}
 {{#imports}}import {{import}}
 {{/imports}}
 
+import org.json.JSONObject
+
 {{^doNotUseRxAndCoroutines}}
 {{#useCoroutines}}
 import kotlinx.coroutines.Dispatchers
@@ -11,6 +13,7 @@ import kotlinx.coroutines.withContext
 {{/useCoroutines}}
 {{/doNotUseRxAndCoroutines}}
 import {{packageName}}.infrastructure.ApiClient
+import {{packageName}}.infrastructure.ApiErrorModel
 import {{packageName}}.infrastructure.ClientException
 import {{packageName}}.infrastructure.ClientError
 import {{packageName}}.infrastructure.ServerException
@@ -62,11 +65,19 @@ import {{packageName}}.infrastructure.toMultiValue
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/infrastructure/Errors.kt.mustache
+++ b/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/infrastructure/Errors.kt.mustache
@@ -2,8 +2,28 @@
 package {{packageName}}.infrastructure
 
 import java.lang.RuntimeException
+import org.json.JSONException
+import org.json.JSONObject
 
-{{#nonPublicApi}}internal {{/nonPublicApi}} data class ApiErrorModel(val code: String? = null, val message: String? = null)
+{{#nonPublicApi}}internal {{/nonPublicApi}} class ApiErrorModel(val body: Any? = null) {
+    val code: String?
+    val message: String?
+
+    init {
+        val (code, message) = if (body is String) {
+            try {
+                val json = JSONObject(body)
+                json.optString("code") to json.optString("message")
+            } catch (e: JSONException) {
+                null to null
+            }
+        } else
+            null to null
+
+        this.code = code
+        this.message = message
+    }
+}
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
 

--- a/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/infrastructure/Errors.kt.mustache
+++ b/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/infrastructure/Errors.kt.mustache
@@ -1,0 +1,20 @@
+@file:Suppress("unused")
+package {{packageName}}.infrastructure
+
+import java.lang.RuntimeException
+
+{{#nonPublicApi}}internal {{/nonPublicApi}} data class ApiErrorModel(val code: String? = null, val message: String? = null)
+
+{{#nonPublicApi}}internal {{/nonPublicApi}}open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
+
+    {{#nonPublicApi}}internal {{/nonPublicApi}}companion object {
+        private const val serialVersionUID: Long = 123L
+    }
+}
+
+{{#nonPublicApi}}internal {{/nonPublicApi}}open class ServerException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
+
+    {{#nonPublicApi}}internal {{/nonPublicApi}}companion object {
+        private const val serialVersionUID: Long = 456L
+    }
+}

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/ApplicationsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/ApplicationsApi.kt
@@ -23,7 +23,10 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.Application
 import com.immutable.sdk.api.model.ListApplicationsResponse
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -67,11 +70,19 @@ class ApplicationsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -123,11 +134,19 @@ class ApplicationsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/ApplicationsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/ApplicationsApi.kt
@@ -23,8 +23,6 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.Application
 import com.immutable.sdk.api.model.ListApplicationsResponse
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -70,18 +68,12 @@ class ApplicationsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -134,18 +126,12 @@ class ApplicationsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/AssetsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/AssetsApi.kt
@@ -23,8 +23,6 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.Asset
 import com.immutable.sdk.api.model.ListAssetsResponse
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -72,18 +70,12 @@ class AssetsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -155,18 +147,12 @@ class AssetsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/AssetsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/AssetsApi.kt
@@ -23,7 +23,10 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.Asset
 import com.immutable.sdk.api.model.ListAssetsResponse
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -69,11 +72,19 @@ class AssetsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -144,11 +155,19 @@ class AssetsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/BalancesApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/BalancesApi.kt
@@ -23,8 +23,6 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.GetBalanceResponse
 import com.immutable.sdk.api.model.ListBalancesResponse
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -71,18 +69,12 @@ class BalancesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -135,18 +127,12 @@ class BalancesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -197,18 +183,12 @@ class BalancesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/BalancesApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/BalancesApi.kt
@@ -23,7 +23,10 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.GetBalanceResponse
 import com.immutable.sdk.api.model.ListBalancesResponse
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -68,11 +71,19 @@ class BalancesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -124,11 +135,19 @@ class BalancesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -178,11 +197,19 @@ class BalancesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/CollectionsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/CollectionsApi.kt
@@ -26,7 +26,10 @@ import com.immutable.sdk.api.model.CreateCollectionRequest
 import com.immutable.sdk.api.model.ListCollectionsResponse
 import com.immutable.sdk.api.model.UpdateCollectionRequest
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -72,11 +75,19 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -129,11 +140,19 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -184,11 +203,19 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -251,11 +278,19 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -328,11 +363,19 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/CollectionsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/CollectionsApi.kt
@@ -26,8 +26,6 @@ import com.immutable.sdk.api.model.CreateCollectionRequest
 import com.immutable.sdk.api.model.ListCollectionsResponse
 import com.immutable.sdk.api.model.UpdateCollectionRequest
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -75,18 +73,12 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -140,18 +132,12 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -203,18 +189,12 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -278,18 +258,12 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -363,18 +337,12 @@ class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/DepositsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/DepositsApi.kt
@@ -25,7 +25,10 @@ import com.immutable.sdk.api.model.GetSignableDepositRequest
 import com.immutable.sdk.api.model.GetSignableDepositResponse
 import com.immutable.sdk.api.model.ListDepositsResponse
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -69,11 +72,19 @@ class DepositsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -122,11 +133,19 @@ class DepositsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -190,11 +209,19 @@ class DepositsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/DepositsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/DepositsApi.kt
@@ -25,8 +25,6 @@ import com.immutable.sdk.api.model.GetSignableDepositRequest
 import com.immutable.sdk.api.model.GetSignableDepositResponse
 import com.immutable.sdk.api.model.ListDepositsResponse
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -72,18 +70,12 @@ class DepositsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -133,18 +125,12 @@ class DepositsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -209,18 +195,12 @@ class DepositsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/MetadataApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/MetadataApi.kt
@@ -25,8 +25,6 @@ import com.immutable.sdk.api.model.MetadataSchemaProperty
 import com.immutable.sdk.api.model.MetadataSchemaRequest
 import com.immutable.sdk.api.model.SuccessResponse
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -75,18 +73,12 @@ class MetadataApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -141,18 +133,12 @@ class MetadataApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -206,18 +192,12 @@ class MetadataApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/MetadataApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/MetadataApi.kt
@@ -25,7 +25,10 @@ import com.immutable.sdk.api.model.MetadataSchemaProperty
 import com.immutable.sdk.api.model.MetadataSchemaRequest
 import com.immutable.sdk.api.model.SuccessResponse
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -72,11 +75,19 @@ class MetadataApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -130,11 +141,19 @@ class MetadataApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -187,11 +206,19 @@ class MetadataApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/MintsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/MintsApi.kt
@@ -28,7 +28,10 @@ import com.immutable.sdk.api.model.MintTokensResponse
 import com.immutable.sdk.api.model.MintTokensResponseV1
 import com.immutable.sdk.api.model.MintableTokenDetails
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -72,11 +75,19 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -127,11 +138,19 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -182,11 +201,19 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -251,11 +278,19 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -369,11 +404,19 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -424,11 +467,19 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/MintsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/MintsApi.kt
@@ -28,8 +28,6 @@ import com.immutable.sdk.api.model.MintTokensResponse
 import com.immutable.sdk.api.model.MintTokensResponseV1
 import com.immutable.sdk.api.model.MintableTokenDetails
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -75,18 +73,12 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -138,18 +130,12 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -201,18 +187,12 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -278,18 +258,12 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -404,18 +378,12 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -467,18 +435,12 @@ class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/OrdersApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/OrdersApi.kt
@@ -33,7 +33,10 @@ import com.immutable.sdk.api.model.GetSignableOrderResponseV1
 import com.immutable.sdk.api.model.ListOrdersResponse
 import com.immutable.sdk.api.model.Order
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -80,11 +83,19 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -140,11 +151,19 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -200,11 +219,19 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -267,11 +294,19 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -320,11 +355,19 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -373,11 +416,19 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -453,11 +504,19 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/OrdersApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/OrdersApi.kt
@@ -33,8 +33,6 @@ import com.immutable.sdk.api.model.GetSignableOrderResponseV1
 import com.immutable.sdk.api.model.ListOrdersResponse
 import com.immutable.sdk.api.model.Order
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -83,18 +81,12 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -151,18 +143,12 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -219,18 +205,12 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -294,18 +274,12 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -355,18 +329,12 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -416,18 +384,12 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -504,18 +466,12 @@ class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/ProjectsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/ProjectsApi.kt
@@ -25,8 +25,6 @@ import com.immutable.sdk.api.model.CreateProjectResponse
 import com.immutable.sdk.api.model.GetProjectsResponse
 import com.immutable.sdk.api.model.Project
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -74,18 +72,12 @@ class ProjectsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -141,18 +133,12 @@ class ProjectsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -211,18 +197,12 @@ class ProjectsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/ProjectsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/ProjectsApi.kt
@@ -25,7 +25,10 @@ import com.immutable.sdk.api.model.CreateProjectResponse
 import com.immutable.sdk.api.model.GetProjectsResponse
 import com.immutable.sdk.api.model.Project
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -71,11 +74,19 @@ class ProjectsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -130,11 +141,19 @@ class ProjectsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -192,11 +211,19 @@ class ProjectsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/PublicApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/PublicApi.kt
@@ -87,7 +87,10 @@ import com.immutable.sdk.api.model.Transfer
 import com.immutable.sdk.api.model.UpdateCollectionRequest
 import com.immutable.sdk.api.model.Withdrawal
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -134,11 +137,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -195,11 +206,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -255,11 +274,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -314,11 +341,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -373,11 +408,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -432,11 +475,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -491,11 +542,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -550,11 +609,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -609,11 +676,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -668,11 +743,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -729,11 +812,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -783,11 +874,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -836,11 +935,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -889,11 +996,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -942,11 +1057,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -996,11 +1119,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1053,11 +1184,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1122,11 +1261,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1184,11 +1331,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1258,11 +1413,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1311,11 +1474,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1364,11 +1535,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1417,11 +1596,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1470,11 +1657,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1523,11 +1718,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1576,11 +1779,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1629,11 +1840,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1682,11 +1901,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1735,11 +1962,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1788,11 +2023,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1841,11 +2084,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1894,11 +2145,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -1947,11 +2206,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2015,11 +2282,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2133,11 +2408,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2188,11 +2471,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2255,11 +2546,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2344,11 +2643,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2477,11 +2784,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2622,11 +2937,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2789,11 +3112,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2862,11 +3193,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -2979,11 +3318,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -3114,11 +3461,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -3240,11 +3595,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -3293,11 +3656,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -3349,11 +3720,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -3411,11 +3790,19 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/PublicApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/PublicApi.kt
@@ -87,8 +87,6 @@ import com.immutable.sdk.api.model.Transfer
 import com.immutable.sdk.api.model.UpdateCollectionRequest
 import com.immutable.sdk.api.model.Withdrawal
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -137,18 +135,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -206,18 +198,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -274,18 +260,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -341,18 +321,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -408,18 +382,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -475,18 +443,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -542,18 +504,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -609,18 +565,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -676,18 +626,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -743,18 +687,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -812,18 +750,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -874,18 +806,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -935,18 +861,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -996,18 +916,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1057,18 +971,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1119,18 +1027,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1184,18 +1086,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1261,18 +1157,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1331,18 +1221,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1413,18 +1297,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1474,18 +1352,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1535,18 +1407,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1596,18 +1462,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1657,18 +1517,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1718,18 +1572,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1779,18 +1627,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1840,18 +1682,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1901,18 +1737,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -1962,18 +1792,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2023,18 +1847,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2084,18 +1902,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2145,18 +1957,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2206,18 +2012,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2282,18 +2082,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2408,18 +2202,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2471,18 +2259,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2546,18 +2328,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2643,18 +2419,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2784,18 +2554,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -2937,18 +2701,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -3112,18 +2870,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -3193,18 +2945,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -3318,18 +3064,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -3461,18 +3201,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -3595,18 +3329,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -3656,18 +3384,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -3720,18 +3442,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -3790,18 +3506,12 @@ class PublicApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/SnapshotApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/SnapshotApi.kt
@@ -23,8 +23,6 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.GetSnapshotRequest
 import com.immutable.sdk.api.model.ListSnapshotBalancesResponse
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -73,18 +71,12 @@ class SnapshotApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/SnapshotApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/SnapshotApi.kt
@@ -23,7 +23,10 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.GetSnapshotRequest
 import com.immutable.sdk.api.model.ListSnapshotBalancesResponse
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -70,11 +73,19 @@ class SnapshotApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePat
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TlvsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TlvsApi.kt
@@ -22,8 +22,6 @@ package com.immutable.sdk.api
 
 import com.immutable.sdk.api.model.GetTLVsResponse
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -70,18 +68,12 @@ class TlvsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TlvsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TlvsApi.kt
@@ -22,7 +22,10 @@ package com.immutable.sdk.api
 
 import com.immutable.sdk.api.model.GetTLVsResponse
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -67,11 +70,19 @@ class TlvsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TokensApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TokensApi.kt
@@ -23,8 +23,6 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.ListTokensResponse
 import com.immutable.sdk.api.model.TokenDetails
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -70,18 +68,12 @@ class TokensApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -132,18 +124,12 @@ class TokensApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TokensApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TokensApi.kt
@@ -23,7 +23,10 @@ package com.immutable.sdk.api
 import com.immutable.sdk.api.model.ListTokensResponse
 import com.immutable.sdk.api.model.TokenDetails
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -67,11 +70,19 @@ class TokensApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -121,11 +132,19 @@ class TokensApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TradesApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TradesApi.kt
@@ -27,8 +27,6 @@ import com.immutable.sdk.api.model.GetSignableTradeResponse
 import com.immutable.sdk.api.model.ListTradesResponse
 import com.immutable.sdk.api.model.Trade
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -76,18 +74,12 @@ class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -141,18 +133,12 @@ class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -202,18 +188,12 @@ class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -274,18 +254,12 @@ class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TradesApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TradesApi.kt
@@ -27,7 +27,10 @@ import com.immutable.sdk.api.model.GetSignableTradeResponse
 import com.immutable.sdk.api.model.ListTradesResponse
 import com.immutable.sdk.api.model.Trade
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -73,11 +76,19 @@ class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -130,11 +141,19 @@ class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -183,11 +202,19 @@ class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -247,11 +274,19 @@ class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath)
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TransfersApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TransfersApi.kt
@@ -31,7 +31,10 @@ import com.immutable.sdk.api.model.GetSignableTransferResponseV1
 import com.immutable.sdk.api.model.ListTransfersResponse
 import com.immutable.sdk.api.model.Transfer
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -77,11 +80,19 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -136,11 +147,19 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -193,11 +212,19 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -246,11 +273,19 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -299,11 +334,19 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -367,11 +410,19 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TransfersApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/TransfersApi.kt
@@ -31,8 +31,6 @@ import com.immutable.sdk.api.model.GetSignableTransferResponseV1
 import com.immutable.sdk.api.model.ListTransfersResponse
 import com.immutable.sdk.api.model.Transfer
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -80,18 +78,12 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -147,18 +139,12 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -212,18 +198,12 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -273,18 +253,12 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -334,18 +308,12 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -410,18 +378,12 @@ class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePa
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/UsersApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/UsersApi.kt
@@ -27,7 +27,10 @@ import com.immutable.sdk.api.model.GetUsersApiResponse
 import com.immutable.sdk.api.model.RegisterUserRequest
 import com.immutable.sdk.api.model.RegisterUserResponse
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -71,11 +74,19 @@ class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -124,11 +135,19 @@ class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -177,11 +196,19 @@ class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -230,11 +257,19 @@ class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/UsersApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/UsersApi.kt
@@ -27,8 +27,6 @@ import com.immutable.sdk.api.model.GetUsersApiResponse
 import com.immutable.sdk.api.model.RegisterUserRequest
 import com.immutable.sdk.api.model.RegisterUserResponse
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -74,18 +72,12 @@ class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -135,18 +127,12 @@ class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -196,18 +182,12 @@ class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -257,18 +237,12 @@ class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/WithdrawalsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/WithdrawalsApi.kt
@@ -27,7 +27,10 @@ import com.immutable.sdk.api.model.GetSignableWithdrawalResponse
 import com.immutable.sdk.api.model.ListWithdrawalsResponse
 import com.immutable.sdk.api.model.Withdrawal
 
+import org.json.JSONObject
+
 import org.openapitools.client.infrastructure.ApiClient
+import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
 import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
@@ -73,11 +76,19 @@ class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -130,11 +141,19 @@ class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -183,11 +202,19 @@ class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }
@@ -253,11 +280,19 @@ class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+                val errorModel = (localVarError.body as? String)?.let {
+                    val json = JSONObject(it)
+                    ApiErrorModel(json.optString("code"), json.optString("message"))
+                }
+                throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
     }

--- a/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/WithdrawalsApi.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/com/immutable/sdk/api/WithdrawalsApi.kt
@@ -27,8 +27,6 @@ import com.immutable.sdk.api.model.GetSignableWithdrawalResponse
 import com.immutable.sdk.api.model.ListWithdrawalsResponse
 import com.immutable.sdk.api.model.Withdrawal
 
-import org.json.JSONObject
-
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.infrastructure.ApiErrorModel
 import org.openapitools.client.infrastructure.ClientException
@@ -76,18 +74,12 @@ class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -141,18 +133,12 @@ class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -202,18 +188,12 @@ class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }
@@ -280,18 +260,12 @@ class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(base
             ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
             ResponseType.ClientError -> {
                 val localVarError = localVarResponse as ClientError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ClientException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
             ResponseType.ServerError -> {
                 val localVarError = localVarResponse as ServerError<*>
-                val errorModel = (localVarError.body as? String)?.let {
-                    val json = JSONObject(it)
-                    ApiErrorModel(json.optString("code"), json.optString("message"))
-                }
+                val errorModel = localVarError.body?.let { ApiErrorModel(localVarError.body) }
                 throw ServerException("${localVarError.statusCode} ${errorModel?.message ?: localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse, errorModel)
             }
         }

--- a/imx-core-sdk-android/generated/src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
@@ -2,8 +2,28 @@
 package org.openapitools.client.infrastructure
 
 import java.lang.RuntimeException
+import org.json.JSONException
+import org.json.JSONObject
 
- data class ApiErrorModel(val code: String? = null, val message: String? = null)
+ class ApiErrorModel(val body: Any? = null) {
+    val code: String?
+    val message: String?
+
+    init {
+        val (code, message) = if (body is String) {
+            try {
+                val json = JSONObject(body)
+                json.optString("code") to json.optString("message")
+            } catch (e: JSONException) {
+                null to null
+            }
+        } else
+            null to null
+
+        this.code = code
+        this.message = message
+    }
+}
 
 open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
 

--- a/imx-core-sdk-android/generated/src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+++ b/imx-core-sdk-android/generated/src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
@@ -3,14 +3,16 @@ package org.openapitools.client.infrastructure
 
 import java.lang.RuntimeException
 
-open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null) : RuntimeException(message) {
+ data class ApiErrorModel(val code: String? = null, val message: String? = null)
+
+open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
 
     companion object {
         private const val serialVersionUID: Long = 123L
     }
 }
 
-open class ServerException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null) : RuntimeException(message) {
+open class ServerException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
 
     companion object {
         private const val serialVersionUID: Long = 456L

--- a/imx-core-sdk-android/src/main/java/com/immutable/sdk/ImmutableException.kt
+++ b/imx-core-sdk-android/src/main/java/com/immutable/sdk/ImmutableException.kt
@@ -16,7 +16,7 @@ class ImmutableException private constructor(
 ) : Exception(message, cause) {
     companion object {
         /**
-         * Exception for when a response is missing required data for the following call.
+         * Exception for when a response is missing required data.
          *
          * @param callName used to identify the step of the workflow that failed e.g. Signable order
          * @param cause the root cause of the error so the consumer can further diagnose
@@ -38,7 +38,7 @@ class ImmutableException private constructor(
             ImmutableException(ImmutableExceptionType.ApiError, "Api call failed: $callName", cause)
 
         /**
-         * Exception for when the issue is due to SDK logic
+         * Exception for when the issue is due to SDK logic.
          *
          * @param message user-facing description of the error
          */
@@ -46,7 +46,7 @@ class ImmutableException private constructor(
             ImmutableException(ImmutableExceptionType.ClientError, "SDK error: $message")
 
         /**
-         * Exception for when a request has been invalidated before sending
+         * Exception for when a request has been invalidated before sending.
          *
          * @param message user-facing description of the error
          */

--- a/imx-core-sdk-android/src/main/java/com/immutable/sdk/workflows/SellWorkflow.kt
+++ b/imx-core-sdk-android/src/main/java/com/immutable/sdk/workflows/SellWorkflow.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletableFuture
 
 private const val CREATE_ORDER = "Create order"
 private const val SIGNABLE_ORDER = "Signable order"
-private const val GET_ASSETS = "Get assets"
+private const val GET_ASSET = "Get asset"
 
 @VisibleForTesting
 internal const val FEE_TYPE_ROYALTY = "royalty"
@@ -72,7 +72,7 @@ private fun getFees(
     sellToken: AssetModel,
     fees: List<FeeEntry>,
     api: AssetsApi
-): CompletableFuture<BigDecimal> = call(GET_ASSETS) {
+): CompletableFuture<BigDecimal> = call(GET_ASSET) {
     val feesList = arrayListOf<FeeEntry>()
     feesList += fees
 

--- a/imx-core-sdk-android/src/main/java/com/immutable/sdk/workflows/Workflow.kt
+++ b/imx-core-sdk-android/src/main/java/com/immutable/sdk/workflows/Workflow.kt
@@ -3,6 +3,10 @@ package com.immutable.sdk.workflows
 import com.immutable.sdk.ImmutableException
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Within the provided call block force unwrap any response values that are required and if they are
+ * missing it will automatically be handled and return an invalidResponse exception.
+ */
 @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException")
 internal fun <T> call(callName: String, call: () -> T): CompletableFuture<T> {
     val future = CompletableFuture<T>()

--- a/sample/src/main/java/com/immutable/sdkdemo/MainActivity.kt
+++ b/sample/src/main/java/com/immutable/sdkdemo/MainActivity.kt
@@ -5,8 +5,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.immutable.sdk.ImmutableXBase
 import com.immutable.sdk.ImmutableXSdk
 import com.immutable.sdk.api.CollectionsApi
-import com.immutable.sdk.api.OrdersApi
-import com.immutable.sdk.api.model.CancelOrderRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -22,8 +20,6 @@ class MainActivity : AppCompatActivity() {
         GlobalScope.launch(Dispatchers.Default) {
             val response = CollectionsApi().listCollections(pageSize = 20)
             println("COLLECTIONS: " + response.result?.joinToString { it.name ?: "no name" })
-
-            OrdersApi().cancelOrder("0", CancelOrderRequest(0, "signature"))
         }
     }
 }

--- a/sample/src/main/java/com/immutable/sdkdemo/MainActivity.kt
+++ b/sample/src/main/java/com/immutable/sdkdemo/MainActivity.kt
@@ -5,6 +5,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.immutable.sdk.ImmutableXBase
 import com.immutable.sdk.ImmutableXSdk
 import com.immutable.sdk.api.CollectionsApi
+import com.immutable.sdk.api.OrdersApi
+import com.immutable.sdk.api.model.CancelOrderRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -20,6 +22,8 @@ class MainActivity : AppCompatActivity() {
         GlobalScope.launch(Dispatchers.Default) {
             val response = CollectionsApi().listCollections(pageSize = 20)
             println("COLLECTIONS: " + response.result?.joinToString { it.name ?: "no name" })
+
+            OrdersApi().cancelOrder("0", CancelOrderRequest(0, "signature"))
         }
     }
 }


### PR DESCRIPTION
Add a new `ApiErrorModel` parameter to `ClientException` and `ServerException`. Also default their error message to whats returned in the body, e.g.: 

        org.openapitools.client.infrastructure.ClientException: 400 Cannot validate request: order_id is a required field

compared to previously:

        org.openapitools.client.infrastructure.ClientException: ClientError: 400