### PR TITLE
ci(github workflows): add token to release Github Package checkout step

### DIFF
--- a/.github/workflows/releaseGithubPackage.yml
+++ b/.github/workflows/releaseGithubPackage.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.PLATFORM_SA_GITHUB_TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
Since changelog and version bump happens directly on the `main` branch, we need to skip its branch protection rules.

This is done by updating the Branch Protection Rule for `main` to allow @platform-sa to bypass the protection.