### PR TITLE
ci(github workflow): move build step earlier for release action

### DIFF
--- a/.github/workflows/releaseGithubPackage.yml
+++ b/.github/workflows/releaseGithubPackage.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           java-version: 11
 
+      - name: Build
+        run: ./gradlew imx-core-sdk-android:build
+
       - name: Generate changelog and bump up version
         uses: TriPSs/conventional-changelog-action@v3
         with:
@@ -26,9 +29,6 @@ jobs:
           skip-git-pull: 'true'
           version-file: './version.yml'
           version-path: 'version'
-
-      - name: Build
-        run: ./gradlew imx-core-sdk-android:build
 
       - name: Publish to GitHub Packages
         run: ./gradlew publish


### PR DESCRIPTION
If the build fails after the changelog is generated, we will need to manually delete the tag that's pushed to remote. So moving build step to before changelog step.