### PR TITLE
refactor: return moonpay url

### DIFF
--- a/imx-core-sdk-kotlin-jvm/build.gradle
+++ b/imx-core-sdk-kotlin-jvm/build.gradle
@@ -128,8 +128,7 @@ dependencies {
     // Web3
     implementation "org.web3j:core:4.8.7-android"
 
-    // Required for Moonpay
-    implementation "androidx.browser:browser:1.4.0"
+    implementation("com.google.guava:guava:31.1-jre")
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "io.mockk:mockk:1.12.3"

--- a/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/ImmutableXSdk.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/ImmutableXSdk.kt
@@ -1,8 +1,5 @@
 package com.immutable.sdk
 
-import android.content.Context
-import android.graphics.Color
-import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import com.immutable.sdk.Constants.DEFAULT_CHROME_CUSTOM_TAB_ADDRESS_BAR_COLOUR
 import com.immutable.sdk.Constants.DEFAULT_MOONPAY_COLOUR_CODE
@@ -193,17 +190,12 @@ object ImmutableXSdk {
      * @throws Throwable if any error occurs
      */
     fun buyCrypto(
-        context: Context,
         signer: Signer,
-        @ColorInt colourInt: Int = Color.parseColor(DEFAULT_CHROME_CUSTOM_TAB_ADDRESS_BAR_COLOUR),
         colourCodeHex: String = DEFAULT_MOONPAY_COLOUR_CODE
-    ) {
+    ): CompletableFuture<String> =
         com.immutable.sdk.workflows.buyCrypto(
             base = base,
-            context = context,
             signer = signer,
-            colourInt = colourInt,
             colourCodeHex = colourCodeHex
         )
-    }
 }


### PR DESCRIPTION
Change `buyCrypto` workflow to return the MoonPay URL instead of launching a Chrome custom tab.

This change is part of the overarching work to make this SDK platform agnostic, moving from Android to Kotlin/JVM. 

The guava dependency was added for the @VisibleForTesting annotation to incrementally contribute to the conversion.