### PR TITLE
refactor: remove android dependencies

### DIFF
--- a/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -3,9 +3,6 @@ package {{packageName}}.infrastructure
 import com.immutable.sdk.BuildConfig
 import com.immutable.sdk.ImmutableXHttpLoggingLevel
 import com.immutable.sdk.ImmutableXSdk
-{{#supportAndroidApiLevel25AndBelow}}
-import android.os.Build
-{{/supportAndroidApiLevel25AndBelow}}
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 {{#jvm-okhttp3}}
@@ -249,17 +246,7 @@ import okhttp3.logging.HttpLoggingInterceptor
         }
         if (T::class.java == File::class.java) {
             // return tempfile
-            {{^supportAndroidApiLevel25AndBelow}}
             val f = java.nio.file.Files.createTempFile("tmp.{{packageName}}", null).toFile()
-            {{/supportAndroidApiLevel25AndBelow}}
-            {{#supportAndroidApiLevel25AndBelow}}
-            val f = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                java.nio.file.Files.createTempFile("tmp.net.medicineone.teleconsultationandroid.openapi.openapicommon", null).toFile()
-            } else {
-                @Suppress("DEPRECATION")
-                createTempFile("tmp.net.medicineone.teleconsultationandroid.openapi.openapicommon", null)
-            }
-            {{/supportAndroidApiLevel25AndBelow}}
             f.deleteOnExit()
             val out = BufferedWriter(FileWriter(f))
             out.write(bodyContent)

--- a/imx-core-sdk-kotlin-jvm/build.gradle
+++ b/imx-core-sdk-kotlin-jvm/build.gradle
@@ -118,16 +118,18 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.7.0'
-
-    // Required for the generated SDK code
+    // Required for the generated API client
     implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
     implementation "com.squareup.okhttp3:okhttp:4.9.3"
     implementation "com.squareup.okhttp3:logging-interceptor:4.9.3"
 
     // Web3
-    implementation "org.web3j:core:4.8.7-android"
+    implementation "org.web3j:core:4.8.7"
 
+    // Json
+    implementation 'org.json:json:20220320'
+
+    // Google Common Java
     implementation("com.google.guava:guava:31.1-jre")
 
     testImplementation 'junit:junit:4.13.2'

--- a/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/ImmutableXSdk.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/ImmutableXSdk.kt
@@ -1,7 +1,6 @@
 package com.immutable.sdk
 
-import androidx.annotation.VisibleForTesting
-import com.immutable.sdk.Constants.DEFAULT_CHROME_CUSTOM_TAB_ADDRESS_BAR_COLOUR
+import com.google.common.annotations.VisibleForTesting
 import com.immutable.sdk.Constants.DEFAULT_MOONPAY_COLOUR_CODE
 import com.immutable.sdk.api.model.FeeEntry
 import com.immutable.sdk.model.AssetModel

--- a/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/crypto/StarkKey.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/crypto/StarkKey.kt
@@ -1,6 +1,6 @@
 package com.immutable.sdk.crypto
 
-import androidx.annotation.VisibleForTesting
+import com.google.common.annotations.VisibleForTesting
 import com.immutable.sdk.Constants
 import com.immutable.sdk.ImmutableException
 import com.immutable.sdk.Signer

--- a/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/extensions/String.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/extensions/String.kt
@@ -1,6 +1,6 @@
 package com.immutable.sdk.extensions
 
-import androidx.annotation.VisibleForTesting
+import com.google.common.annotations.VisibleForTesting
 import com.immutable.sdk.Constants
 import com.immutable.sdk.Constants.CHAR_ZERO
 import com.immutable.sdk.Constants.HEX_PREFIX


### PR DESCRIPTION
Remove Android specific dependencies and references.

- Import org.json explicitly to prepare for Android removal. We use these JSON apis which are supplied by Android implicitly.
- Replace androidx annotations with google annotations

This PR is part of the overarching work to convert from Android to Kotlin/JVM and is into the ConvertToKotlinLib feature branch.