### PR TITLE
docs: update installation guide

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,5 +9,3 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
-        with:
-          token: ${{ secrets.PLATFORM_SA_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,22 @@ See the [API reference documentation](https://docs.x.immutable.com/reference) fo
 
 ## Installation
 
-1. Add dependency to your app `build.gradle` file:
+1. Create an Access Token [(see here)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `read:packages` enabled.
+2. Add the GitHub package as a repository either in your `build.gradle` file or `settings.gradle` if you have one:
+```gradle
+repositories {
+    maven {
+        name = "imx-core-sdk-kotlin-jvm"
+        url = uri("https://maven.pkg.github.com/immutable/imx-core-sdk-kotlin-jvm")
+        credentials {
+            username = "<github username>"
+            password = "<access token>"
+        }
+    }
+}
+```
+Note: will look to have this accessible directly via the `mavenCentral()` repository in the future.
+3. Add dependency to your app `build.gradle` file:
 ```gradle
 dependencies {
     implementation 'com.immutable.sdk:imx-core-sdk-kotlin-jvm:$version'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,4 +7,4 @@
 3. Create a PR (branch name needs to start with `releases/`)
 4. Get approval for your PR
 5. Merge your PR
-6. If the [Release to Github Package](https://github.com/immutable/imx-core-sdk-kotlin-jvm/actions/workflows/releaseGithubPackage.yml) workflow is successful, you should see the new version in [Packages - com.immutable.sdk.imx-core-sdk-kotlin-jvm](https://github.com/immutable/imx-core-sdk-kotlin-jvm/packages/1410108).
+6. If the [Release to Github Package](https://github.com/immutable/imx-core-sdk-kotlin-jvm/actions/workflows/releaseGithubPackage.yml) workflow is successful, you should see the new version in [Packages - com.immutable.sdk.imx-core-sdk-kotlin-jvm](https://github.com/orgs/immutable/packages?repo_name=imx-core-sdk-kotlin-jvm).

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/BuildConfig.java
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/BuildConfig.java
@@ -1,4 +1,4 @@
 package com.immutable.sdk;
 public class BuildConfig {
-    public static String VERSION = "0.5.0";
+    public static String VERSION = "0.5.2";
 }

--- a/version.yml
+++ b/version.yml
@@ -1,1 +1,1 @@
-version: 0.5.0
+version: 0.5.2


### PR DESCRIPTION
Update guide to show how to import from the GitHub package

Using a GitHub package via maven requires extra set up steps and needs to be outlined explicitly.

Also bumped the version. 