### PR TITLE
feat: add ethSignature to workflows requests

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXSdk.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXSdk.kt
@@ -2,7 +2,7 @@ package com.immutable.sdk
 
 import com.google.common.annotations.VisibleForTesting
 import com.immutable.sdk.Constants.DEFAULT_MOONPAY_COLOUR_CODE
-import com.immutable.sdk.api.model.FeeEntry
+import com.immutable.sdk.api.model.*
 import com.immutable.sdk.model.AssetModel
 import com.immutable.sdk.model.Erc721Asset
 import okhttp3.logging.HttpLoggingInterceptor
@@ -112,7 +112,7 @@ object ImmutableXSdk {
         fees: List<FeeEntry> = emptyList(),
         signer: Signer,
         starkSigner: StarkSigner
-    ): CompletableFuture<Int> =
+    ): CompletableFuture<CreateTradeResponse> =
         com.immutable.sdk.workflows.buy(orderId, fees, signer, starkSigner)
 
     /**
@@ -133,7 +133,7 @@ object ImmutableXSdk {
         fees: List<FeeEntry> = emptyList(),
         signer: Signer,
         starkSigner: StarkSigner
-    ): CompletableFuture<Int> {
+    ): CompletableFuture<CreateOrderResponse> {
         return com.immutable.sdk.workflows.sell(
             asset,
             sellToken,
@@ -154,9 +154,10 @@ object ImmutableXSdk {
     @Suppress("LongParameterList")
     fun cancel(
         orderId: String,
+        signer: Signer,
         starkSigner: StarkSigner
-    ): CompletableFuture<Int> =
-        com.immutable.sdk.workflows.cancel(orderId, starkSigner)
+    ): CompletableFuture<CancelOrderResponse> =
+        com.immutable.sdk.workflows.cancel(orderId, signer, starkSigner)
 
     /**
      * This is a utility function that will chain the necessary calls to transfer a token.
@@ -174,7 +175,7 @@ object ImmutableXSdk {
         recipientAddress: String,
         signer: Signer,
         starkSigner: StarkSigner,
-    ): CompletableFuture<Int> =
+    ): CompletableFuture<CreateTransferResponse> =
         com.immutable.sdk.workflows.transfer(token, recipientAddress, signer, starkSigner)
 
     /**

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/Crypto.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/Crypto.kt
@@ -20,8 +20,8 @@ object Crypto {
     }
 
     private fun importRecoveryParam(v: BigInteger): String {
-        val comp = BigInteger("27")
-        return if (v.compareTo(comp) != -1)
+        val comp = BigInteger("27") // 1b
+        return if (v.compareTo(comp) != -1) // if recovery param is greater than 27
             v.subtract(comp).toString(HEX_RADIX)
         else
             v.toString(HEX_RADIX)

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/BuyWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/BuyWorkflow.kt
@@ -118,6 +118,6 @@ private fun createTrade(
             includeFees = true
         ),
         xImxEthAddress = signatures.ethAddress,
-        xImxEthSignature = signatures.ethSignature
+        xImxEthSignature = signatures.serialisedEthSignature
     )
 }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/CancelWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/CancelWorkflow.kt
@@ -56,6 +56,6 @@ private fun cancelOrder(
         orderId,
         CancelOrderRequest(orderId.toInt(), signatures.starkSignature),
         xImxEthAddress = signatures.ethAddress,
-        xImxEthSignature = signatures.ethSignature
+        xImxEthSignature = signatures.serialisedEthSignature
     )
 }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/SellWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/SellWorkflow.kt
@@ -94,6 +94,6 @@ private fun createOrder(
             includeFees = true
         ),
         xImxEthAddress = signatures.ethAddress,
-        xImxEthSignature = signatures.ethSignature
+        xImxEthSignature = signatures.serialisedEthSignature
     )
 }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/TransferWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/TransferWorkflow.kt
@@ -108,7 +108,7 @@ private fun createTransfer(
                         )
                     ),
                     xImxEthAddress = signatures.ethAddress,
-                    xImxEthSignature = signatures.ethSignature
+                    xImxEthSignature = signatures.serialisedEthSignature
                 )
             )
         } catch (e: Exception) {

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/Workflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/Workflow.kt
@@ -27,3 +27,11 @@ internal fun <T> completeExceptionally(ex: Throwable): CompletableFuture<T> =
     CompletableFuture<T>().apply {
         completeExceptionally(ex)
     }
+
+/**
+ * Data model for workflows to hold the ethAddress and signatures for transactions
+ */
+internal class WorkflowSignatures(val ethAddress: String) {
+    lateinit var ethSignature: String
+    lateinit var starkSignature: String
+}

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/Workflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/Workflow.kt
@@ -1,6 +1,7 @@
 package com.immutable.sdk.workflows
 
 import com.immutable.sdk.ImmutableException
+import com.immutable.sdk.crypto.Crypto
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -34,4 +35,8 @@ internal fun <T> completeExceptionally(ex: Throwable): CompletableFuture<T> =
 internal class WorkflowSignatures(val ethAddress: String) {
     lateinit var ethSignature: String
     lateinit var starkSignature: String
+
+    // The ethSignature needs to be serialised before being supplied to the API
+    val serialisedEthSignature: String
+        get() { return Crypto.serialiseEthSignature(ethSignature) }
 }

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/CancelWorkflowTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/CancelWorkflowTest.kt
@@ -1,13 +1,10 @@
 package com.immutable.sdk.workflows
 
-import com.immutable.sdk.ImmutableException
-import com.immutable.sdk.StarkSigner
-import com.immutable.sdk.TestException
+import com.immutable.sdk.*
 import com.immutable.sdk.api.OrdersApi
 import com.immutable.sdk.api.model.CancelOrderResponse
 import com.immutable.sdk.api.model.GetSignableCancelOrderResponse
 import com.immutable.sdk.crypto.StarkKey
-import com.immutable.sdk.testFuture
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -19,15 +16,23 @@ import org.junit.Test
 import org.openapitools.client.infrastructure.ClientException
 import java.util.concurrent.CompletableFuture
 
-private const val SIGNATURE =
+private const val ADDRESS = "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f"
+private const val STARK_SIGNATURE =
     "0x5a263fad6f17f23e7c7ea833d058f3656d3fe464baf13f6f5ccba9a2466ba2ce4c4a250231bcac" +
         "7beb165aec4c9b049b4ba40ad8dd287dc79b92b1ffcf20cdcf1b"
+private const val ETH_SIGNATURE =
+    "0x5a263fad6f17f23e7c7ea833d058f3656d3fe464baf13f6f5ccba9a2466ba2ce4c4a250231bcac" +
+        "7beb165aec4c9b049b4ba40ad8dd287dc79b92b1ffcf20cdcf1a"
 private const val ORDER_ID = 4511
 private const val PAYLOAD_HASH = "cancelPayloadHash"
+private const val SIGNABLE_MESSAGE = "signableMessage"
 
 class CancelWorkflowTest {
     @MockK
     private lateinit var ordersApi: OrdersApi
+
+    @MockK
+    private lateinit var signer: Signer
 
     @MockK
     private lateinit var starkSigner: StarkSigner
@@ -38,20 +43,27 @@ class CancelWorkflowTest {
     @MockK
     private lateinit var cancelOrderResponse: CancelOrderResponse
 
-    private lateinit var signatureFuture: CompletableFuture<String>
+    private lateinit var addressFuture: CompletableFuture<String>
+    private lateinit var starkSignatureFuture: CompletableFuture<String>
+    private lateinit var ethSignatureFuture: CompletableFuture<String>
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
 
-        signatureFuture = CompletableFuture<String>()
-        every { starkSigner.signMessage(any()) } returns signatureFuture
+        addressFuture = CompletableFuture<String>()
+        every { signer.getAddress() } returns addressFuture
+        starkSignatureFuture = CompletableFuture<String>()
+        every { starkSigner.signMessage(any()) } returns starkSignatureFuture
+        ethSignatureFuture = CompletableFuture<String>()
+        every { signer.signMessage(any()) } returns ethSignatureFuture
 
         mockkObject(StarkKey)
-        every { StarkKey.sign(any(), any()) } returns SIGNATURE
+        every { StarkKey.sign(any(), any()) } returns STARK_SIGNATURE
 
         every { ordersApi.getSignableCancelOrder(any()) } returns signableCancelOrderResponse
         every { signableCancelOrderResponse.payloadHash } returns PAYLOAD_HASH
+        every { signableCancelOrderResponse.signableMessage } returns SIGNABLE_MESSAGE
     }
 
     @After
@@ -61,26 +73,53 @@ class CancelWorkflowTest {
 
     private fun createCancelFuture() = cancel(
         orderId = ORDER_ID.toString(),
+        signer = signer,
         starkSigner = starkSigner,
         ordersApi = ordersApi
     )
 
     @Test
     fun testCancelSuccess() {
-        signatureFuture.complete(SIGNATURE)
-        every { ordersApi.cancelOrder(any(), any(), any(), any()) } returns cancelOrderResponse
-        every { cancelOrderResponse.orderId } returns ORDER_ID
+        addressFuture.complete(ADDRESS)
+        starkSignatureFuture.complete(STARK_SIGNATURE)
+        ethSignatureFuture.complete(ETH_SIGNATURE)
+        every { ordersApi.cancelOrder(any(), any(), ADDRESS, ETH_SIGNATURE) } returns cancelOrderResponse
 
         testFuture(
             future = createCancelFuture(),
-            expectedResult = ORDER_ID,
+            expectedResult = cancelOrderResponse,
             expectedError = null
         )
     }
 
     @Test
+    fun testCancelFailedOnGetAddress() {
+        addressFuture.completeExceptionally(TestException())
+
+        testFuture(
+            future = createCancelFuture(),
+            expectedResult = null,
+            expectedError = TestException()
+        )
+    }
+
+    @Test
     fun testCancelFailedOnStarkSignature() {
-        signatureFuture.completeExceptionally(TestException())
+        addressFuture.complete(ADDRESS)
+        starkSignatureFuture.completeExceptionally(TestException())
+
+        testFuture(
+            future = createCancelFuture(),
+            expectedResult = null,
+            expectedError = TestException()
+        )
+    }
+
+    @Test
+    fun testCancelFailedOnEthSignature() {
+        addressFuture.complete(ADDRESS)
+        starkSignatureFuture.complete(STARK_SIGNATURE)
+        ethSignatureFuture.completeExceptionally(TestException())
 
         testFuture(
             future = createCancelFuture(),
@@ -91,7 +130,7 @@ class CancelWorkflowTest {
 
     @Test
     fun testCancelFailedOnGetSignableCancelOrder() {
-        signatureFuture.complete(SIGNATURE)
+        addressFuture.complete(ADDRESS)
         every { ordersApi.getSignableCancelOrder(any()) } throws ClientException()
 
         testFuture(
@@ -103,8 +142,10 @@ class CancelWorkflowTest {
 
     @Test
     fun testCancelFailedOnCancelOrder() {
-        signatureFuture.complete(SIGNATURE)
-        every { ordersApi.cancelOrder(any(), any(), any(), any()) } throws ClientException()
+        addressFuture.complete(ADDRESS)
+        starkSignatureFuture.complete(STARK_SIGNATURE)
+        ethSignatureFuture.complete(ETH_SIGNATURE)
+        every { ordersApi.cancelOrder(any(), any(), ADDRESS, ETH_SIGNATURE) } throws ClientException()
 
         testFuture(
             future = createCancelFuture(),


### PR DESCRIPTION
Update all workflows to add the ethSignature and ethAddress headers to the transaction requests.

Currently the ethSignature and ethAddress headers are optional but will be required in the future, this is in preparation for  that change.

Also changed the workflows to return the full response and not just the id. 