### PR TITLE
fix: fixMessage branch not stripping hex

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
@@ -209,7 +209,7 @@ object StarkKey {
             message
         } else {
             assert(message.length == 63)
-            "${msg}0"
+            "${message}0"
         }
     }
 }

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
@@ -93,7 +93,7 @@ class StarkKeyTest {
         assertEquals("123456789abcdef", StarkKey.fixMessage("0x123456789abcdef"))
 
         assertEquals(
-            "0x074180eaec7e68712b5a0fbf5d63a70c33940c9b02e60565e36f84d705b669e0",
+            "074180eaec7e68712b5a0fbf5d63a70c33940c9b02e60565e36f84d705b669e0",
             StarkKey.fixMessage(
                 "0x074180eaec7e68712b5a0fbf5d63a70c33940c9b02e60565e36f84d705b669e"
             )


### PR DESCRIPTION
Fix returning the function parameter instead of the fixed message in the else branch.

This was a bug where it was returning the original message instead of the hex stripped message with the correct number of characters.