### PR TITLE
refactor: rename ImmutableXSdk to ImmutableXCore

### DIFF
--- a/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -2,7 +2,7 @@ package {{packageName}}.infrastructure
 
 import com.immutable.sdk.BuildConfig
 import com.immutable.sdk.ImmutableXHttpLoggingLevel
-import com.immutable.sdk.ImmutableXSdk
+import com.immutable.sdk.ImmutableXCore
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 {{#jvm-okhttp3}}
@@ -103,7 +103,7 @@ import okhttp3.logging.HttpLoggingInterceptor
                     )
                 }
                 .addInterceptor(HttpLoggingInterceptor().apply {
-                    level = when (ImmutableXSdk.httpLoggingLevel) {
+                    level = when (ImmutableXCore.httpLoggingLevel) {
                         ImmutableXHttpLoggingLevel.None -> HttpLoggingInterceptor.Level.NONE
                         ImmutableXHttpLoggingLevel.Basic -> HttpLoggingInterceptor.Level.BASIC
                         ImmutableXHttpLoggingLevel.Headers -> HttpLoggingInterceptor.Level.HEADERS

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ dependencies {
 ```
 4. Set the correct environment (Ropsten or Production/Mainnet)
 ```kt
-ImmutableXSdk.setBase(ImmutableXBase.Ropsten)
+ImmutableXCore.setBase(ImmutableXBase.Ropsten)
 ```
 
 ## Usage

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -2,7 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.immutable.sdk.BuildConfig
 import com.immutable.sdk.ImmutableXHttpLoggingLevel
-import com.immutable.sdk.ImmutableXSdk
+import com.immutable.sdk.ImmutableXCore
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
@@ -60,7 +60,7 @@ open class ApiClient(val baseUrl: String) {
                     )
                 }
                 .addInterceptor(HttpLoggingInterceptor().apply {
-                    level = when (ImmutableXSdk.httpLoggingLevel) {
+                    level = when (ImmutableXCore.httpLoggingLevel) {
                         ImmutableXHttpLoggingLevel.None -> HttpLoggingInterceptor.Level.NONE
                         ImmutableXHttpLoggingLevel.Basic -> HttpLoggingInterceptor.Level.BASIC
                         ImmutableXHttpLoggingLevel.Headers -> HttpLoggingInterceptor.Level.HEADERS

--- a/imx-core-sdk-kotlin-jvm/packages.md
+++ b/imx-core-sdk-kotlin-jvm/packages.md
@@ -6,7 +6,7 @@ It contains the API Client for interacting with the platform, workflows for doin
 
 # Package com.immutable.sdk
 
-Contains the Core SDK entry point [ImmutableXSdk].
+Contains the Core SDK entry point [ImmutableXCore].
 
 # Package com.immutable.sdk.api
 

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXCore.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXCore.kt
@@ -57,7 +57,7 @@ internal const val KEY_BASE_URL = "org.openapitools.client.baseUrl"
  * You can configure the environment or use any of the provided utility workflows which chain
  * the necessary calls to perform standard actions (e.g. buy, sell etc).
  */
-object ImmutableXSdk {
+object ImmutableXCore {
 
     private var base: ImmutableXBase = ImmutableXBase.Ropsten
     internal var httpLoggingLevel = ImmutableXHttpLoggingLevel.None

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/BuyCryptoWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/BuyCryptoWorkflow.kt
@@ -63,7 +63,7 @@ internal fun buyCrypto(
         try {
             val address = signer.getAddress().get()
             check(isWalletRegistered(address, usersApi)) {
-                "Wallet is not registered. Call ImmutableXSdk.registerOffChain() " +
+                "Wallet is not registered. Call ImmutableXCore.registerOffChain() " +
                     "to register your wallet."
             }
 

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/ImmutableXCoreTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/ImmutableXCoreTest.kt
@@ -9,12 +9,12 @@ import java.util.*
 
 private const val API_URL = "url"
 
-class ImmutableXSdkTest {
+class ImmutableXCoreTest {
 
     @MockK
     private lateinit var properties: Properties
 
-    private lateinit var sdk: ImmutableXSdk
+    private lateinit var sdk: ImmutableXCore
 
     @Before
     fun setUp() {
@@ -27,7 +27,7 @@ class ImmutableXSdkTest {
         every { System.getProperties() } returns properties
         every { properties.setProperty(any(), any()) } returns mockk()
 
-        sdk = spyk(ImmutableXSdk)
+        sdk = spyk(ImmutableXCore)
     }
 
     @After


### PR DESCRIPTION
Renamed `ImmutableXSdk` to `ImmutableXCore`.

This change is to keep consistent with naming on other platforms. It's also unusual for a class to include Sdk in the name. 