### PR TITLE
refactor: rename cancel to cancelOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ for new features.
 
 ### Changed
 
-for changes in existing functionality.
+* Updated OpenAPI spec which includes breaking change to the `Transfer` object, replacing `data` and `type` with `token` field.
+* Renamed `cancel` workflow to `cancelOrder`  
 
 ### Deprecated
 

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXCore.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXCore.kt
@@ -124,7 +124,7 @@ object ImmutableXCore {
      * @param signer represents the users L1 wallet to get the address
      * @param starkSigner represents the users L2 wallet used to sign and verify the L2 transaction
      *
-     * @return a [CompletableFuture] that will provide the cancelled Order id if successful.
+     * @return a [CompletableFuture] that will provide the Order id if successful.
      */
     @Suppress("LongParameterList")
     fun sell(
@@ -149,10 +149,10 @@ object ImmutableXCore {
      * @param orderId the id of an existing order to be bought
      * @param starkSigner represents the users L2 wallet used to sign and verify the L2 transaction
      *
-     * @return a [CompletableFuture] that will provide the Order id if successful.
+     * @return a [CompletableFuture] that will provide the cancelled Order id if successful.
      */
     @Suppress("LongParameterList")
-    fun cancel(
+    fun cancelOrder(
         orderId: String,
         signer: Signer,
         starkSigner: StarkSigner


### PR DESCRIPTION
Renamed `cancel` to `cancelOrder` as it was unclear by name what it was cancelling.

Also fixed the return docs on `cancelOrder` and `sell`