### PR TITLE
docs: fix buyCrypto comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The generation always happens on preBuild so triggering a project build will reg
 Rx provides a `fromFuture` method that will trigger `future.get()` which is a blocking call so it must be moved off the main thread.
 
 Disposing the resulting observable will not cancel the future so that needs to be done manually using `doOnDispose`.
-```
+```kt
 val future = ImmutableWallet.cancel(orderId)
 Observable.fromFuture(future)
     .subscribeOn(Schedulers.io())
@@ -116,12 +116,12 @@ Observable.fromFuture(future)
 The Kotlin team has a set of packages for jdk8 that provide an easy extension for using CompletableFuture.
 
 First add this import to your project:
-```
+```kt
 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutines_version"
 ```
 
 Then simply call `.await()` on the workflow `CompletableFuture` and wrap it with a try/catch to handle any exceptions.
-```
+```kt
 launch(Dispatchers.Default) {
     try {
         val id = ImmutableWallet.cancel(orderId).await()

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXCore.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXCore.kt
@@ -179,12 +179,11 @@ object ImmutableXCore {
         com.immutable.sdk.workflows.transfer(token, recipientAddress, signer, starkSigner)
 
     /**
-     * Launches a Chrome Custom Tab to buy cryptocurrencies via Moonpay
+     * Gets a URL to MoonPay that provides a service for buying crypto directly on Immutable in exchange for fiat.
      *
-     * @param context the context for launching the Custom Tabs activity
+     * It is recommended to open this URL in a Chrome Custom Tab.
+     *
      * @param signer represents the users L1 wallet to get the address
-     * @param colourInt (optional) the colour of the Chrome Custom Tab address bar. The default
-     * value is [DEFAULT_CHROME_CUSTOM_TAB_ADDRESS_BAR_COLOUR]
      * @param colourCodeHex The color code in hex (e.g. #00818e) for the Moon pay widget main color. It is used for buttons,
      * links and highlighted text.
      * @throws Throwable if any error occurs

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/BuyCryptoWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/BuyCryptoWorkflow.kt
@@ -46,7 +46,7 @@ private const val HEADER_ACCEPT = "Accept"
 private const val HEADER_CONTENT_TYPE = "Content-Type"
 
 /**
- * Launches a Chrome Custom Tab to buy cryptocurrencies via Moonpay
+ * Gets a URL to MoonPay that provides a service for buying crypto directly on Immutable in exchange for fiat.
  *
  * @throws Exception if anything error occurs
  */


### PR DESCRIPTION
Update buyCrypto docs to better describe what it does.

Before converting this library to be platform agnostic `buyCrypto` launched a Chrome Custom Tab for Android.

Also added language tags to some README snippets.