### PR TITLE
feat: add StandardStarkSigner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-for new features.
+* Added `StandardStarkSigner` as the generic implementation of `StarkSigner`
 
 ### Changed
 
 * Updated OpenAPI spec which includes breaking change to the `Transfer` object, replacing `data` and `type` with `token` field.
 * Renamed `cancel` workflow to `cancelOrder`  
+* `StarkKey.sign` was made private, use `StandardStarkSigner` to handle this case
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 ---
 
-# ImmutableX Core SDK Kotlin/JVM
+# Immutable X Core SDK Kotlin/JVM
 
-The Immutable Core SDK Kotlin/JVM provides convenient access to the Immutable API's for applications written on the Immutable X platform.
+The Immutable X Core SDK Kotlin/JVM provides convenient access to the Immutable API's for applications written on the Immutable X platform.
 
 ## Documentation
 
@@ -66,21 +66,21 @@ View the [OpenAPI spec](openapi.json) for a full list of API requests available 
 
 Utility functions that will chain necessary API calls to complete a process or perform a transaction.
 
-* Register a user with ImmutableX and returns the Stark key pair
+* Register a user with Immutable X
 * Buy cryptocurrency via Moonpay
 * Buy ERC721
 * Sell ERC721
-* Cancel listing
+* Cancel order
 * Transfer ERC20/ERC721/ETH
 
 ### Wallet Connection
 
-In order to use any workflow functions, you will need to pass in the connected wallet provider. This means you will need to implement your own Wallet L1 [Signer](https://github.com/immutable/imx-core-sdk-kotlin-jvm/blob/main/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Signer.kt) and L2 [StarkSigner](https://github.com/immutable/imx-core-sdk-kotlin-jvm/blob/main/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Signer.kt).
+In order to use any workflow functions, you will need to pass in the connected wallet provider. This means you will need to implement your own Wallet L1 [Signer](https://github.com/immutable/imx-core-sdk-kotlin-jvm/blob/main/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Signer.kt).
 
-Once you have a `Signer` instance you can generate the user's Stark key pair and use the result to implement a `StarkSigner`.
+Once you have created a `Signer` instance you can generate the user's Stark key pair and use it to create an instance of `StandardStarkSigner`, an implementation of `StarkSigner`.
 ```kt
 StarkKey.generate(signer).whenComplete { keyPair, error ->
-    StarkKey.sign(keyPair, "0x5369676e2074686973")
+    val starkSigner = StandardStarkSigner(keyPair)
 }
 ```
 

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXCore.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableXCore.kt
@@ -157,7 +157,7 @@ object ImmutableXCore {
         signer: Signer,
         starkSigner: StarkSigner
     ): CompletableFuture<CancelOrderResponse> =
-        com.immutable.sdk.workflows.cancel(orderId, signer, starkSigner)
+        com.immutable.sdk.workflows.cancelOrder(orderId, signer, starkSigner)
 
     /**
      * This is a utility function that will chain the necessary calls to transfer a token.

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Signer.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Signer.kt
@@ -29,18 +29,20 @@ interface Signer {
 /**
  * This represents the Immutable X Wallet on Layer 2 and will have reference to the user's Stark key pair
  * for signing L2 transactions.
+ *
+ * See [StandardStarkSigner] as the implementation of this.
  */
 interface StarkSigner {
     /**
      * Signs the [message] with the user's L2 Stark keys.
      *
-     * When implementing this, make sure [message] is in hex format and pass it and the L2 Stark key pair to the
-     * [com.immutable.sdk.crypto.StarkKey.sign] function.
+     * When implementing this, make sure [message] is in hex format.
      */
     fun signMessage(message: String): CompletableFuture<String>
 
     /**
-     * Returns a CompletableFuture that resolves to the account address.
+     * Returns a CompletableFuture that resolves to the account address, must be in a Stark friendly format which can
+     * be gotten using the extension ECKeyPair.getStarkPublicKey().
      *
      * This is a CompletableFuture so that a Signer can be designed around an asynchronous source,
      * such as hardware wallets.

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/StandardStarkSigner.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/StandardStarkSigner.kt
@@ -1,0 +1,27 @@
+package com.immutable.sdk
+
+import com.google.common.annotations.VisibleForTesting
+import com.immutable.sdk.crypto.StarkKey
+import com.immutable.sdk.extensions.getStarkPublicKey
+import org.web3j.crypto.ECKeyPair
+import java.util.concurrent.CompletableFuture
+
+/**
+ * A simple implementation of [StarkSigner] that holds the [ECKeyPair] in memory.
+ */
+class StandardStarkSigner(@VisibleForTesting internal val keyPair: ECKeyPair) : StarkSigner {
+    override fun getAddress(): CompletableFuture<String> {
+        return CompletableFuture.supplyAsync { keyPair.getStarkPublicKey() }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun signMessage(message: String): CompletableFuture<String> {
+        val future = CompletableFuture<String>()
+        try {
+            future.complete(StarkKey.sign(keyPair, message))
+        } catch (e: Exception) {
+            future.completeExceptionally(e)
+        }
+        return future
+    }
+}

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
@@ -151,7 +151,7 @@ object StarkKey {
      * @return Stark signature
      */
     @Suppress("MagicNumber")
-    fun sign(keyPair: ECKeyPair, msg: String): String {
+    internal fun sign(keyPair: ECKeyPair, msg: String): String {
         val fixMessage = fixMessage(msg)
         val signer = ECDSASigner(HMacDSAKCalculator(SHA256Digest()))
 

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/CancelWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/CancelWorkflow.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture
 private const val SIGNABLE_CANCEL_ORDER = "Signable cancel order"
 private const val CANCEL_ORDER = "Cancel order"
 
-internal fun cancel(
+internal fun cancelOrder(
     orderId: String,
     signer: Signer,
     starkSigner: StarkSigner,

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/StandardStarkSignerTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/StandardStarkSignerTest.kt
@@ -1,0 +1,37 @@
+package com.immutable.sdk
+
+import com.immutable.sdk.crypto.StarkKey
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.mockkObject
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.web3j.crypto.ECKeyPair
+import java.math.BigInteger
+
+class StandardStarkSignerTest {
+    private lateinit var starkSigner: StandardStarkSigner
+    private val keyPair = ECKeyPair(BigInteger.ONE, BigInteger.TEN)
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        starkSigner = StandardStarkSigner(keyPair)
+    }
+
+    @Test
+    fun testStarkSignSuccess() {
+        mockkObject(StarkKey)
+        every { StarkKey.sign(keyPair, "Sign this") } returns "result"
+        assertEquals("result", starkSigner.signMessage("Sign this").get())
+    }
+
+    @Test(expected = Exception::class)
+    fun testStarkSignError() {
+        mockkObject(StarkKey)
+        every { StarkKey.sign(keyPair, "Sign this") } throws Exception()
+        starkSigner.signMessage("Sign this").get()
+    }
+}

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/CancelWorkflowTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/CancelWorkflowTest.kt
@@ -71,7 +71,7 @@ class CancelWorkflowTest {
         unmockkAll()
     }
 
-    private fun createCancelFuture() = cancel(
+    private fun createCancelFuture() = cancelOrder(
         orderId = ORDER_ID.toString(),
         signer = signer,
         starkSigner = starkSigner,

--- a/sample/src/main/java/com/immutable/sdkdemo/SdkDemo.kt
+++ b/sample/src/main/java/com/immutable/sdkdemo/SdkDemo.kt
@@ -1,3 +1,5 @@
+package com.immutable.sdkdemo
+
 import com.immutable.sdk.api.CollectionsApi
 
 fun main() {


### PR DESCRIPTION
Added `StandardStarkSigner` as the default implementation to use for `StarkSigner`.

- Changed `StarkKey.sign` to be private as it should only be used via the StarkSigner implementation
- Added tests to `ImmutableXCore` to make sure parameters are correctly being passed to the workflows which already have tests