### PR TITLE
docs: add dokka and update comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ for new features.
 
 ### Changed
 
-for changes in existing functionality.
+* Changed `Crypto` object to internal
+* Changed `ECKeyPair.getStarkPublicKey()` extension to internal
 
 ### Deprecated
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ buildscript {
     dependencies {
         classpath "org.jacoco:org.jacoco.core:0.8.7"
         classpath 'org.yaml:snakeyaml:1.30'
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/imx-core-sdk-kotlin-jvm/build.gradle
+++ b/imx-core-sdk-kotlin-jvm/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version "1.6.20"
+    id 'org.jetbrains.kotlin.jvm'
     id 'java-library'
 
     // If updating openapi version check the custom templates are still relevant in
@@ -10,6 +10,7 @@ plugins {
     id "org.jlleitschuh.gradle.ktlint" version "10.2.1"
     id "io.gitlab.arturbosch.detekt" version "1.20.0-RC1"
     id 'jacoco'
+    id 'org.jetbrains.dokka'
 }
 
 def getArtifactId = { ->
@@ -74,11 +75,9 @@ tasks.create('generateBuildConfig') {
 }
 
 // Generate all apis before every build
-compileKotlin.dependsOn(tasks.openApiGenerate)
-compileKotlin.dependsOn(tasks.ktlintCheck)
-compileKotlin.dependsOn(tasks.detekt)
-tasks.openApiGenerate.dependsOn(tasks.cleanGeneratedClient)
-tasks.openApiGenerate.dependsOn(tasks.generateBuildConfig)
+compileKotlin.dependsOn(tasks.openApiGenerate, tasks.ktlintCheck, tasks.detekt)
+tasks.openApiGenerate.dependsOn(tasks.cleanGeneratedClient, tasks.generateBuildConfig)
+tasks.dokkaHtml.dependsOn(tasks.openApiGenerate)
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
@@ -197,6 +196,19 @@ detekt {
     allRules = false // activate all available (even unstable) rules.
     config = files("../.github/detekt/config/detekt.yml")
     // point to your custom config defining rules to run, overwriting default behavior
+}
+
+dokkaHtml {
+    dokkaSourceSets {
+        configureEach {
+            perPackageOption {
+                matchingRegex.set("org.openapitools.*")
+                suppress.set(true)
+            }
+
+            includes.from("packages.md")
+        }
+    }
 }
 
 // ** Start code coverage **

--- a/imx-core-sdk-kotlin-jvm/packages.md
+++ b/imx-core-sdk-kotlin-jvm/packages.md
@@ -1,21 +1,23 @@
 # Module imx-core-sdk-kotlin-jvm
 
-This module is the Immutable X Core SDK for Kotlin/JVM.
-
-It contains the API Client for interacting with the platform, workflows for doing standard transactions, and layer 2 signing functions.
+The Immutable X Core SDK Kotlin/JVM provides convenient access to the Immutable API's for applications written on the Immutable X platform.
 
 # Package com.immutable.sdk
 
-Contains the Core SDK entry point [ImmutableXCore].
+All SDK specific classes and types
 
 # Package com.immutable.sdk.api
 
-Contains the generated API client.
+The auto-generated API clients
 
 # Package com.immutable.sdk.api.model
 
-Contains the generated API models used by the client.
+The auto-generated models used with the API clients
 
 # Package com.immutable.sdk.model
 
-Contains some convenient models to make using workflows more user friendly.
+User friendly models for [ImmutableXCore] utility functions
+
+# Package com.immutable.sdk.crypto
+
+Stark key pair generation

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/Crypto.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/Crypto.kt
@@ -6,7 +6,7 @@ import com.immutable.sdk.Constants
 import com.immutable.sdk.Constants.HEX_RADIX
 import java.math.BigInteger
 
-object Crypto {
+internal object Crypto {
     @Suppress("MagicNumber")
     fun serialiseEthSignature(signature: String, size: Int = 64): String {
         val sig = signature.hexRemovePrefix()

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
@@ -32,6 +32,9 @@ private val SECP_ORDER = BigInteger(
 private const val SHA_256 = "SHA-256"
 private const val GENERATE_ERROR_MESSAGE = "Failed to generate Stark key pair"
 
+/**
+ * An object to generate a Stark key pair from a given Ethereum signer
+ */
 object StarkKey {
     /**
      * Hashes the given [input] using SHA-256

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/extensions/ECKeyPair.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/extensions/ECKeyPair.kt
@@ -6,7 +6,7 @@ import org.web3j.crypto.ECKeyPair
 /**
  * Utility to convert the public key into a Stark friendly hex address
  */
-fun ECKeyPair.getStarkPublicKey() =
+internal fun ECKeyPair.getStarkPublicKey() =
     publicKey.toString(Constants.HEX_RADIX)
         .sanitizeBytes()
         .hexToByteArray()

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/model/SignableTokenData.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/model/SignableTokenData.kt
@@ -1,7 +1,11 @@
 package com.immutable.sdk.model
 
+import com.immutable.sdk.api.model.SignableToken
 import com.squareup.moshi.Json
 
+/**
+ * An object representing the `data` field of [SignableToken].
+ */
 data class SignableTokenData(
     @Json(name = "token_address")
     val tokenAddress: String? = null,

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version "1.6.20"
+    id 'org.jetbrains.kotlin.jvm'
     id 'application'
 }
 


### PR DESCRIPTION
Add dokka plugin and update code comments.

- For dokka to work the kotlin plugin needed to be explicitly set as a dependency. 
- Removed public visibility from `Crypto` object and `getStarkPublicKey` extension
- Adding dokka to be auto-generate API reference docs to be added to the Immutable docs for this SDK