### PR TITLE
feat: make API clients private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ github.properties
 # jvm-okhttp/api.mustache is the only file we want to keep
 .openapi-generator/templates/kotlin-client/*
 !.openapi-generator/templates/kotlin-client/libraries
+!.openapi-generator/templates/kotlin-client/data_class.mustache

--- a/.openapi-generator/templates/kotlin-client/data_class.mustache
+++ b/.openapi-generator/templates/kotlin-client/data_class.mustache
@@ -1,0 +1,113 @@
+{{^multiplatform}}
+{{#gson}}
+import com.google.gson.annotations.SerializedName
+{{/gson}}
+{{#moshi}}
+import com.squareup.moshi.Json
+{{#moshiCodeGen}}
+import com.squareup.moshi.JsonClass
+{{/moshiCodeGen}}
+{{/moshi}}
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonProperty
+{{#discriminator}}
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+{{/discriminator}}
+{{/jackson}}
+{{#kotlinx_serialization}}
+import {{#serializableModel}}kotlinx.serialization.Serializable as KSerializable{{/serializableModel}}{{^serializableModel}}kotlinx.serialization.Serializable{{/serializableModel}}
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Contextual
+{{#hasEnums}}
+{{/hasEnums}}
+{{/kotlinx_serialization}}
+{{#parcelizeModels}}
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+{{/parcelizeModels}}
+{{/multiplatform}}
+{{#multiplatform}}
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+{{/multiplatform}}
+{{#serializableModel}}
+import java.io.Serializable
+{{/serializableModel}}
+
+/**
+ * {{{description}}}
+ *
+{{#allVars}}
+ * @param {{{name}}} {{{description}}}
+{{/allVars}}
+ */
+{{#parcelizeModels}}
+@Parcelize
+{{/parcelizeModels}}
+{{#multiplatform}}{{^discriminator}}@Serializable{{/discriminator}}{{/multiplatform}}{{#kotlinx_serialization}}{{#serializableModel}}@KSerializable{{/serializableModel}}{{^serializableModel}}@Serializable{{/serializableModel}}{{/kotlinx_serialization}}{{#moshi}}{{#moshiCodeGen}}@JsonClass(generateAdapter = true){{/moshiCodeGen}}{{/moshi}}{{#jackson}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{/jackson}}
+{{#isDeprecated}}
+@Deprecated(message = "This schema is deprecated.")
+{{/isDeprecated}}
+{{#discriminator}}interface{{/discriminator}}{{^discriminator}}data class{{/discriminator}} {{classname}}{{^discriminator}} (
+
+{{#allVars}}
+{{#required}}{{>data_class_req_var}}{{/required}}{{^required}}{{>data_class_opt_var}}{{/required}}{{^-last}},{{/-last}}
+
+{{/allVars}}
+){{/discriminator}}{{#parent}}{{^serializableModel}}{{^parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{#serializableModel}}{{^parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Serializable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{^serializableModel}}{{#parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{#serializableModel}}{{#parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Serializable, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}{{^parcelizeModels}} : Serializable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{^serializableModel}}{{#parcelizeModels}} : Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}{{#parcelizeModels}} : Serializable, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#vendorExtensions.x-has-data-class-body}} {
+{{/vendorExtensions.x-has-data-class-body}}
+{{#serializableModel}}
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+{{/serializableModel}}
+{{#discriminator}}{{#vars}}{{#required}}
+{{>interface_req_var}}{{/required}}{{^required}}
+{{>interface_opt_var}}{{/required}}{{/vars}}{{/discriminator}}
+{{#hasEnums}}
+{{#vars}}
+{{#isEnum}}
+    /**
+     * {{{description}}}
+     *
+     * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
+     */
+    {{^multiplatform}}
+    {{#kotlinx_serialization}}
+    {{#serializableModel}}@KSerializable{{/serializableModel}}{{^serializableModel}}@Serializable{{/serializableModel}}
+    {{/kotlinx_serialization}}
+    {{/multiplatform}}
+    {{#multiplatform}}
+    @Serializable
+    {{/multiplatform}}
+    enum class {{{nameInCamelCase}}}(val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}) {
+    {{#allowableValues}}
+    {{#enumVars}}
+        {{^multiplatform}}
+        {{#moshi}}
+        @Json(name = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        {{/moshi}}
+        {{#gson}}
+        @SerializedName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        {{/gson}}
+        {{#jackson}}
+        @JsonProperty(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        {{/jackson}}
+        {{#kotlinx_serialization}}
+        @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        {{/kotlinx_serialization}}
+        {{/multiplatform}}
+        {{#multiplatform}}
+        @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        {{/multiplatform}}
+    {{/enumVars}}
+    {{/allowableValues}}
+    }
+{{/isEnum}}
+{{/vars}}
+{{/hasEnums}}
+{{#vendorExtensions.x-has-data-class-body}}
+}
+{{/vendorExtensions.x-has-data-class-body}}

--- a/imx-core-sdk-kotlin-jvm/build.gradle
+++ b/imx-core-sdk-kotlin-jvm/build.gradle
@@ -37,7 +37,7 @@ openApiGenerate {
     invokerPackage = "com.immutable.sdk.invoker"
     modelPackage = "com.immutable.sdk.api.model"
     // For version 5.3.0 this override is performed to add null as a default for !required parameters
-    templateDir = "$rootDir/.openapi-generator/templates/kotlin-client/libraries/jvm-okhttp"
+    templateDir = "$rootDir/.openapi-generator/templates/kotlin-client/"
     configOptions = [
             dateLibrary: "java8"
     ]
@@ -50,6 +50,9 @@ openApiGenerate {
             // this makes it really difficult to cast it to List<SellOrders>. So instead we create an
             // AssetOrderDetails model (with List<SellOrders>) for 'Asset.orders' field to use.
             OrderDetails: "com.immutable.sdk.api.model.AssetOrderDetails"
+    ]
+    additionalProperties = [
+            nonPublicApi: true
     ]
 }
 

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/AssetsApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/AssetsApi.kt
@@ -36,7 +36,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class AssetsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class AssetsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/BalancesApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/BalancesApi.kt
@@ -36,7 +36,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class BalancesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class BalancesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/CollectionsApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/CollectionsApi.kt
@@ -39,7 +39,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class CollectionsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/DepositsApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/DepositsApi.kt
@@ -38,7 +38,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class DepositsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class DepositsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/EncodingApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/EncodingApi.kt
@@ -36,7 +36,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class EncodingApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class EncodingApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/MetadataApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/MetadataApi.kt
@@ -38,7 +38,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class MetadataApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class MetadataApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/MintsApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/MintsApi.kt
@@ -39,7 +39,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class MintsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/OrdersApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/OrdersApi.kt
@@ -44,7 +44,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class OrdersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/ProjectsApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/ProjectsApi.kt
@@ -38,7 +38,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class ProjectsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class ProjectsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/TokensApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/TokensApi.kt
@@ -36,7 +36,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class TokensApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class TokensApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/TradesApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/TradesApi.kt
@@ -40,7 +40,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class TradesApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/TransfersApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/TransfersApi.kt
@@ -44,7 +44,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class TransfersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/UsersApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/UsersApi.kt
@@ -40,7 +40,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class UsersApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/WithdrawalsApi.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/com/immutable/sdk/api/WithdrawalsApi.kt
@@ -40,7 +40,7 @@ import org.openapitools.client.infrastructure.ResponseType
 import org.openapitools.client.infrastructure.Success
 import org.openapitools.client.infrastructure.toMultiValue
 
-class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
+internal class WithdrawalsApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     companion object {
         @JvmStatic
         val defaultBasePath: String by lazy {

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -1,8 +1,8 @@
 package org.openapitools.client.infrastructure
 
-typealias MultiValueMap = MutableMap<String,List<String>>
+internal typealias MultiValueMap = MutableMap<String,List<String>>
 
-fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
+internal fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
     "pipe" -> "|"
@@ -10,12 +10,12 @@ fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     else -> ""
 }
 
-val defaultMultiValueConverter: (item: Any?) -> String = { item -> "$item" }
+internal val defaultMultiValueConverter: (item: Any?) -> String = { item -> "$item" }
 
-fun <T : Any?> toMultiValue(items: Array<T>, collectionFormat: String, map: (item: T) -> String = defaultMultiValueConverter)
+internal fun <T : Any?> toMultiValue(items: Array<T>, collectionFormat: String, map: (item: T) -> String = defaultMultiValueConverter)
         = toMultiValue(items.asIterable(), collectionFormat, map)
 
-fun <T : Any?> toMultiValue(items: Iterable<T>, collectionFormat: String, map: (item: T) -> String = defaultMultiValueConverter): List<String> {
+internal fun <T : Any?> toMultiValue(items: Iterable<T>, collectionFormat: String, map: (item: T) -> String = defaultMultiValueConverter): List<String> {
     return when(collectionFormat) {
         "multi" -> items.map(map)
         else -> listOf(items.joinToString(separator = collectionDelimiter(collectionFormat), transform = map))

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -33,8 +33,8 @@ import java.util.Locale
 import com.squareup.moshi.adapter
 import okhttp3.logging.HttpLoggingInterceptor
 
-open class ApiClient(val baseUrl: String) {
-    companion object {
+internal open class ApiClient(val baseUrl: String) {
+    internal companion object {
         protected const val ContentType = "Content-Type"
         protected const val Accept = "Accept"
         protected const val Authorization = "Authorization"

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
@@ -1,41 +1,41 @@
 package org.openapitools.client.infrastructure
 
-enum class ResponseType {
+internal enum class ResponseType {
     Success, Informational, Redirection, ClientError, ServerError
 }
 
-interface Response
+internal interface Response
 
-abstract class ApiInfrastructureResponse<T>(val responseType: ResponseType): Response {
+internal abstract class ApiInfrastructureResponse<T>(val responseType: ResponseType): Response {
     abstract val statusCode: Int
     abstract val headers: Map<String,List<String>>
 }
 
-class Success<T>(
+internal class Success<T>(
     val data: T,
     override val statusCode: Int = -1,
     override val headers: Map<String, List<String>> = mapOf()
 ): ApiInfrastructureResponse<T>(ResponseType.Success)
 
-class Informational<T>(
+internal class Informational<T>(
     val statusText: String,
     override val statusCode: Int = -1,
     override val headers: Map<String, List<String>> = mapOf()
 ) : ApiInfrastructureResponse<T>(ResponseType.Informational)
 
-class Redirection<T>(
+internal class Redirection<T>(
     override val statusCode: Int = -1,
     override val headers: Map<String, List<String>> = mapOf()
 ) : ApiInfrastructureResponse<T>(ResponseType.Redirection)
 
-class ClientError<T>(
+internal class ClientError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,
     override val headers: Map<String, List<String>> = mapOf()
 ) : ApiInfrastructureResponse<T>(ResponseType.ClientError)
 
-class ServerError<T>(
+internal class ServerError<T>(
     val message: String? = null,
     val body: Any? = null,
     override val statusCode: Int = -1,

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import java.math.BigDecimal
 
-class BigDecimalAdapter {
+internal class BigDecimalAdapter {
     @ToJson
     fun toJson(value: BigDecimal): String {
         return value.toPlainString()

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import java.math.BigInteger
 
-class BigIntegerAdapter {
+internal class BigIntegerAdapter {
     @ToJson
     fun toJson(value: BigInteger): String {
         return value.toString()

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
@@ -3,7 +3,7 @@ package org.openapitools.client.infrastructure
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 
-class ByteArrayAdapter {
+internal class ByteArrayAdapter {
     @ToJson
     fun toJson(data: ByteArray): String = String(data)
 

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
@@ -5,7 +5,7 @@ import java.lang.RuntimeException
 import org.json.JSONException
 import org.json.JSONObject
 
- class ApiErrorModel(val body: Any? = null) {
+internal  class ApiErrorModel(val body: Any? = null) {
     val code: String?
     val message: String?
 
@@ -25,16 +25,16 @@ import org.json.JSONObject
     }
 }
 
-open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
+internal open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
 
-    companion object {
+    internal companion object {
         private const val serialVersionUID: Long = 123L
     }
 }
 
-open class ServerException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
+internal open class ServerException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null, val errorModel: ApiErrorModel? = null) : RuntimeException(message) {
 
-    companion object {
+    internal companion object {
         private const val serialVersionUID: Long = 456L
     }
 }

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.ToJson
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-class LocalDateAdapter {
+internal class LocalDateAdapter {
     @ToJson
     fun toJson(value: LocalDate): String {
         return DateTimeFormatter.ISO_LOCAL_DATE.format(value)

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.ToJson
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class LocalDateTimeAdapter {
+internal class LocalDateTimeAdapter {
     @ToJson
     fun toJson(value: LocalDateTime): String {
         return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(value)

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.ToJson
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
-class OffsetDateTimeAdapter {
+internal class OffsetDateTimeAdapter {
     @ToJson
     fun toJson(value: OffsetDateTime): String {
         return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(value)

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,7 +8,7 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig<T>(
+internal data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
@@ -3,6 +3,6 @@ package org.openapitools.client.infrastructure
 /**
  * Provides enumerated HTTP verbs
  */
-enum class RequestMethod {
+internal enum class RequestMethod {
     GET, DELETE, HEAD, OPTIONS, PATCH, POST, PUT
 }

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -5,20 +5,20 @@ import okhttp3.Response
 /**
  * Provides an extension to evaluation whether the response is a 1xx code
  */
-val Response.isInformational : Boolean get() = this.code in 100..199
+internal val Response.isInformational : Boolean get() = this.code in 100..199
 
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-val Response.isRedirect : Boolean get() = this.code in 300..399
+internal val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**
  * Provides an extension to evaluation whether the response is a 4xx code
  */
-val Response.isClientError : Boolean get() = this.code in 400..499
+internal val Response.isClientError : Boolean get() = this.code in 400..499
 
 /**
  * Provides an extension to evaluation whether the response is a 5xx (Standard) through 999 (non-standard) code
  */
-val Response.isServerError : Boolean get() = this.code in 500..999
+internal val Response.isServerError : Boolean get() = this.code in 500..999

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -3,7 +3,7 @@ package org.openapitools.client.infrastructure
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
-object Serializer {
+internal object Serializer {
     @JvmStatic
     val moshiBuilder: Moshi.Builder = Moshi.Builder()
         .add(OffsetDateTimeAdapter())

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/URIAdapter.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/URIAdapter.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import java.net.URI
 
-class URIAdapter {
+internal class URIAdapter {
     @ToJson
     fun toJson(uri: URI) = uri.toString()
 

--- a/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/UUIDAdapter.kt
+++ b/imx-core-sdk-kotlin-jvm/generated/src/main/kotlin/org/openapitools/client/infrastructure/UUIDAdapter.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import java.util.UUID
 
-class UUIDAdapter {
+internal class UUIDAdapter {
     @ToJson
     fun toJson(uuid: UUID) = uuid.toString()
 

--- a/sample/src/main/java/com/immutable/sdkdemo/SdkDemo.kt
+++ b/sample/src/main/java/com/immutable/sdkdemo/SdkDemo.kt
@@ -1,7 +1,5 @@
 package com.immutable.sdkdemo
 
-import com.immutable.sdk.api.CollectionsApi
-
 fun main() {
-    println("List of collections: ${CollectionsApi().listCollections().result.joinToString { it.name }}")
+    // Todo: print list of collections
 }


### PR DESCRIPTION
- Set `nonPublicApi` to true for the open API generation to privatise the generated clients.
- Add a modified template for `data_class.mustache` to keep models public as they will be exposed via the wrapped api methods in `ImmutableX`