### PR TITLE
feat: deposit ERC721

### DIFF
--- a/contracts/IERC721.sol
+++ b/contracts/IERC721.sol
@@ -1,0 +1,4 @@
+pragma solidity ^0.8.11;
+// SPDX-License-Identifier: MIT
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/contracts/IERC721_sol_IERC721.java
+++ b/imx-core-sdk-kotlin-jvm/src/main/java/com/immutable/sdk/contracts/IERC721_sol_IERC721.java
@@ -1,0 +1,340 @@
+package com.immutable.sdk.contracts;
+
+import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.web3j.abi.EventEncoder;
+import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.Bool;
+import org.web3j.abi.datatypes.Event;
+import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.generated.Uint256;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.RemoteCall;
+import org.web3j.protocol.core.RemoteFunctionCall;
+import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.BaseEventResponse;
+import org.web3j.protocol.core.methods.response.Log;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.tx.Contract;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.gas.ContractGasProvider;
+
+/**
+ * <p>Auto generated code.
+ * <p><strong>Do not modify!</strong>
+ * <p>Please use the <a href="https://docs.web3j.io/command_line.html">web3j command line tools</a>,
+ * or the org.web3j.codegen.SolidityFunctionWrapperGenerator in the 
+ * <a href="https://github.com/web3j/web3j/tree/master/codegen">codegen module</a> to update.
+ *
+ * <p>Generated with web3j version 1.4.1.
+ */
+@SuppressWarnings("rawtypes")
+public class IERC721_sol_IERC721 extends Contract {
+    public static final String BINARY = "";
+
+    public static final String FUNC_APPROVE = "approve";
+
+    public static final String FUNC_BALANCEOF = "balanceOf";
+
+    public static final String FUNC_GETAPPROVED = "getApproved";
+
+    public static final String FUNC_ISAPPROVEDFORALL = "isApprovedForAll";
+
+    public static final String FUNC_OWNEROF = "ownerOf";
+
+    public static final String FUNC_safeTransferFrom = "safeTransferFrom";
+
+    public static final String FUNC_SETAPPROVALFORALL = "setApprovalForAll";
+
+    public static final String FUNC_SUPPORTSINTERFACE = "supportsInterface";
+
+    public static final String FUNC_TRANSFERFROM = "transferFrom";
+
+    public static final Event APPROVAL_EVENT = new Event("Approval", 
+            Arrays.<TypeReference<?>>asList(new TypeReference<Address>(true) {}, new TypeReference<Address>(true) {}, new TypeReference<Uint256>(true) {}));
+    ;
+
+    public static final Event APPROVALFORALL_EVENT = new Event("ApprovalForAll", 
+            Arrays.<TypeReference<?>>asList(new TypeReference<Address>(true) {}, new TypeReference<Address>(true) {}, new TypeReference<Bool>() {}));
+    ;
+
+    public static final Event TRANSFER_EVENT = new Event("Transfer", 
+            Arrays.<TypeReference<?>>asList(new TypeReference<Address>(true) {}, new TypeReference<Address>(true) {}, new TypeReference<Uint256>(true) {}));
+    ;
+
+    @Deprecated
+    protected IERC721_sol_IERC721(String contractAddress, Web3j web3j, Credentials credentials, BigInteger gasPrice, BigInteger gasLimit) {
+        super(BINARY, contractAddress, web3j, credentials, gasPrice, gasLimit);
+    }
+
+    protected IERC721_sol_IERC721(String contractAddress, Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider) {
+        super(BINARY, contractAddress, web3j, credentials, contractGasProvider);
+    }
+
+    @Deprecated
+    protected IERC721_sol_IERC721(String contractAddress, Web3j web3j, TransactionManager transactionManager, BigInteger gasPrice, BigInteger gasLimit) {
+        super(BINARY, contractAddress, web3j, transactionManager, gasPrice, gasLimit);
+    }
+
+    protected IERC721_sol_IERC721(String contractAddress, Web3j web3j, TransactionManager transactionManager, ContractGasProvider contractGasProvider) {
+        super(BINARY, contractAddress, web3j, transactionManager, contractGasProvider);
+    }
+
+    public List<ApprovalEventResponse> getApprovalEvents(TransactionReceipt transactionReceipt) {
+        List<Contract.EventValuesWithLog> valueList = extractEventParametersWithLog(APPROVAL_EVENT, transactionReceipt);
+        ArrayList<ApprovalEventResponse> responses = new ArrayList<ApprovalEventResponse>(valueList.size());
+        for (Contract.EventValuesWithLog eventValues : valueList) {
+            ApprovalEventResponse typedResponse = new ApprovalEventResponse();
+            typedResponse.log = eventValues.getLog();
+            typedResponse.owner = (String) eventValues.getIndexedValues().get(0).getValue();
+            typedResponse.approved = (String) eventValues.getIndexedValues().get(1).getValue();
+            typedResponse.tokenId = (BigInteger) eventValues.getIndexedValues().get(2).getValue();
+            responses.add(typedResponse);
+        }
+        return responses;
+    }
+
+    public Flowable<ApprovalEventResponse> approvalEventFlowable(EthFilter filter) {
+        return web3j.ethLogFlowable(filter).map(new Function<Log, ApprovalEventResponse>() {
+            @Override
+            public ApprovalEventResponse apply(Log log) {
+                Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(APPROVAL_EVENT, log);
+                ApprovalEventResponse typedResponse = new ApprovalEventResponse();
+                typedResponse.log = log;
+                typedResponse.owner = (String) eventValues.getIndexedValues().get(0).getValue();
+                typedResponse.approved = (String) eventValues.getIndexedValues().get(1).getValue();
+                typedResponse.tokenId = (BigInteger) eventValues.getIndexedValues().get(2).getValue();
+                return typedResponse;
+            }
+        });
+    }
+
+    public Flowable<ApprovalEventResponse> approvalEventFlowable(DefaultBlockParameter startBlock, DefaultBlockParameter endBlock) {
+        EthFilter filter = new EthFilter(startBlock, endBlock, getContractAddress());
+        filter.addSingleTopic(EventEncoder.encode(APPROVAL_EVENT));
+        return approvalEventFlowable(filter);
+    }
+
+    public List<ApprovalForAllEventResponse> getApprovalForAllEvents(TransactionReceipt transactionReceipt) {
+        List<Contract.EventValuesWithLog> valueList = extractEventParametersWithLog(APPROVALFORALL_EVENT, transactionReceipt);
+        ArrayList<ApprovalForAllEventResponse> responses = new ArrayList<ApprovalForAllEventResponse>(valueList.size());
+        for (Contract.EventValuesWithLog eventValues : valueList) {
+            ApprovalForAllEventResponse typedResponse = new ApprovalForAllEventResponse();
+            typedResponse.log = eventValues.getLog();
+            typedResponse.owner = (String) eventValues.getIndexedValues().get(0).getValue();
+            typedResponse.operator = (String) eventValues.getIndexedValues().get(1).getValue();
+            typedResponse.approved = (Boolean) eventValues.getNonIndexedValues().get(0).getValue();
+            responses.add(typedResponse);
+        }
+        return responses;
+    }
+
+    public Flowable<ApprovalForAllEventResponse> approvalForAllEventFlowable(EthFilter filter) {
+        return web3j.ethLogFlowable(filter).map(new Function<Log, ApprovalForAllEventResponse>() {
+            @Override
+            public ApprovalForAllEventResponse apply(Log log) {
+                Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(APPROVALFORALL_EVENT, log);
+                ApprovalForAllEventResponse typedResponse = new ApprovalForAllEventResponse();
+                typedResponse.log = log;
+                typedResponse.owner = (String) eventValues.getIndexedValues().get(0).getValue();
+                typedResponse.operator = (String) eventValues.getIndexedValues().get(1).getValue();
+                typedResponse.approved = (Boolean) eventValues.getNonIndexedValues().get(0).getValue();
+                return typedResponse;
+            }
+        });
+    }
+
+    public Flowable<ApprovalForAllEventResponse> approvalForAllEventFlowable(DefaultBlockParameter startBlock, DefaultBlockParameter endBlock) {
+        EthFilter filter = new EthFilter(startBlock, endBlock, getContractAddress());
+        filter.addSingleTopic(EventEncoder.encode(APPROVALFORALL_EVENT));
+        return approvalForAllEventFlowable(filter);
+    }
+
+    public List<TransferEventResponse> getTransferEvents(TransactionReceipt transactionReceipt) {
+        List<Contract.EventValuesWithLog> valueList = extractEventParametersWithLog(TRANSFER_EVENT, transactionReceipt);
+        ArrayList<TransferEventResponse> responses = new ArrayList<TransferEventResponse>(valueList.size());
+        for (Contract.EventValuesWithLog eventValues : valueList) {
+            TransferEventResponse typedResponse = new TransferEventResponse();
+            typedResponse.log = eventValues.getLog();
+            typedResponse.from = (String) eventValues.getIndexedValues().get(0).getValue();
+            typedResponse.to = (String) eventValues.getIndexedValues().get(1).getValue();
+            typedResponse.tokenId = (BigInteger) eventValues.getIndexedValues().get(2).getValue();
+            responses.add(typedResponse);
+        }
+        return responses;
+    }
+
+    public Flowable<TransferEventResponse> transferEventFlowable(EthFilter filter) {
+        return web3j.ethLogFlowable(filter).map(new Function<Log, TransferEventResponse>() {
+            @Override
+            public TransferEventResponse apply(Log log) {
+                Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(TRANSFER_EVENT, log);
+                TransferEventResponse typedResponse = new TransferEventResponse();
+                typedResponse.log = log;
+                typedResponse.from = (String) eventValues.getIndexedValues().get(0).getValue();
+                typedResponse.to = (String) eventValues.getIndexedValues().get(1).getValue();
+                typedResponse.tokenId = (BigInteger) eventValues.getIndexedValues().get(2).getValue();
+                return typedResponse;
+            }
+        });
+    }
+
+    public Flowable<TransferEventResponse> transferEventFlowable(DefaultBlockParameter startBlock, DefaultBlockParameter endBlock) {
+        EthFilter filter = new EthFilter(startBlock, endBlock, getContractAddress());
+        filter.addSingleTopic(EventEncoder.encode(TRANSFER_EVENT));
+        return transferEventFlowable(filter);
+    }
+
+    public RemoteFunctionCall<TransactionReceipt> approve(String to, BigInteger tokenId) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(
+                FUNC_APPROVE, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(160, to), 
+                new org.web3j.abi.datatypes.generated.Uint256(tokenId)), 
+                Collections.<TypeReference<?>>emptyList());
+        return executeRemoteCallTransaction(function);
+    }
+
+    public RemoteFunctionCall<BigInteger> balanceOf(String owner) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_BALANCEOF, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(160, owner)), 
+                Arrays.<TypeReference<?>>asList(new TypeReference<Uint256>() {}));
+        return executeRemoteCallSingleValueReturn(function, BigInteger.class);
+    }
+
+    public RemoteFunctionCall<String> getApproved(BigInteger tokenId) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_GETAPPROVED, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(tokenId)), 
+                Arrays.<TypeReference<?>>asList(new TypeReference<Address>() {}));
+        return executeRemoteCallSingleValueReturn(function, String.class);
+    }
+
+    public RemoteFunctionCall<Boolean> isApprovedForAll(String owner, String operator) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_ISAPPROVEDFORALL, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(160, owner), 
+                new org.web3j.abi.datatypes.Address(160, operator)), 
+                Arrays.<TypeReference<?>>asList(new TypeReference<Bool>() {}));
+        return executeRemoteCallSingleValueReturn(function, Boolean.class);
+    }
+
+    public RemoteFunctionCall<String> ownerOf(BigInteger tokenId) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_OWNEROF, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(tokenId)), 
+                Arrays.<TypeReference<?>>asList(new TypeReference<Address>() {}));
+        return executeRemoteCallSingleValueReturn(function, String.class);
+    }
+
+    public RemoteFunctionCall<TransactionReceipt> safeTransferFrom(String from, String to, BigInteger tokenId) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(
+                FUNC_safeTransferFrom, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(160, from), 
+                new org.web3j.abi.datatypes.Address(160, to), 
+                new org.web3j.abi.datatypes.generated.Uint256(tokenId)), 
+                Collections.<TypeReference<?>>emptyList());
+        return executeRemoteCallTransaction(function);
+    }
+
+    public RemoteFunctionCall<TransactionReceipt> safeTransferFrom(String from, String to, BigInteger tokenId, byte[] data) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(
+                FUNC_safeTransferFrom, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(160, from), 
+                new org.web3j.abi.datatypes.Address(160, to), 
+                new org.web3j.abi.datatypes.generated.Uint256(tokenId), 
+                new org.web3j.abi.datatypes.DynamicBytes(data)), 
+                Collections.<TypeReference<?>>emptyList());
+        return executeRemoteCallTransaction(function);
+    }
+
+    public RemoteFunctionCall<TransactionReceipt> setApprovalForAll(String operator, Boolean _approved) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(
+                FUNC_SETAPPROVALFORALL, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(160, operator), 
+                new org.web3j.abi.datatypes.Bool(_approved)), 
+                Collections.<TypeReference<?>>emptyList());
+        return executeRemoteCallTransaction(function);
+    }
+
+    public RemoteFunctionCall<Boolean> supportsInterface(byte[] interfaceId) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_SUPPORTSINTERFACE, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes4(interfaceId)), 
+                Arrays.<TypeReference<?>>asList(new TypeReference<Bool>() {}));
+        return executeRemoteCallSingleValueReturn(function, Boolean.class);
+    }
+
+    public RemoteFunctionCall<TransactionReceipt> transferFrom(String from, String to, BigInteger tokenId) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(
+                FUNC_TRANSFERFROM, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(160, from), 
+                new org.web3j.abi.datatypes.Address(160, to), 
+                new org.web3j.abi.datatypes.generated.Uint256(tokenId)), 
+                Collections.<TypeReference<?>>emptyList());
+        return executeRemoteCallTransaction(function);
+    }
+
+    @Deprecated
+    public static IERC721_sol_IERC721 load(String contractAddress, Web3j web3j, Credentials credentials, BigInteger gasPrice, BigInteger gasLimit) {
+        return new IERC721_sol_IERC721(contractAddress, web3j, credentials, gasPrice, gasLimit);
+    }
+
+    @Deprecated
+    public static IERC721_sol_IERC721 load(String contractAddress, Web3j web3j, TransactionManager transactionManager, BigInteger gasPrice, BigInteger gasLimit) {
+        return new IERC721_sol_IERC721(contractAddress, web3j, transactionManager, gasPrice, gasLimit);
+    }
+
+    public static IERC721_sol_IERC721 load(String contractAddress, Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider) {
+        return new IERC721_sol_IERC721(contractAddress, web3j, credentials, contractGasProvider);
+    }
+
+    public static IERC721_sol_IERC721 load(String contractAddress, Web3j web3j, TransactionManager transactionManager, ContractGasProvider contractGasProvider) {
+        return new IERC721_sol_IERC721(contractAddress, web3j, transactionManager, contractGasProvider);
+    }
+
+    public static RemoteCall<IERC721_sol_IERC721> deploy(Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider) {
+        return deployRemoteCall(IERC721_sol_IERC721.class, web3j, credentials, contractGasProvider, BINARY, "");
+    }
+
+    @Deprecated
+    public static RemoteCall<IERC721_sol_IERC721> deploy(Web3j web3j, Credentials credentials, BigInteger gasPrice, BigInteger gasLimit) {
+        return deployRemoteCall(IERC721_sol_IERC721.class, web3j, credentials, gasPrice, gasLimit, BINARY, "");
+    }
+
+    public static RemoteCall<IERC721_sol_IERC721> deploy(Web3j web3j, TransactionManager transactionManager, ContractGasProvider contractGasProvider) {
+        return deployRemoteCall(IERC721_sol_IERC721.class, web3j, transactionManager, contractGasProvider, BINARY, "");
+    }
+
+    @Deprecated
+    public static RemoteCall<IERC721_sol_IERC721> deploy(Web3j web3j, TransactionManager transactionManager, BigInteger gasPrice, BigInteger gasLimit) {
+        return deployRemoteCall(IERC721_sol_IERC721.class, web3j, transactionManager, gasPrice, gasLimit, BINARY, "");
+    }
+
+    public static class ApprovalEventResponse extends BaseEventResponse {
+        public String owner;
+
+        public String approved;
+
+        public BigInteger tokenId;
+    }
+
+    public static class ApprovalForAllEventResponse extends BaseEventResponse {
+        public String owner;
+
+        public String operator;
+
+        public Boolean approved;
+    }
+
+    public static class TransferEventResponse extends BaseEventResponse {
+        public String from;
+
+        public String to;
+
+        public BigInteger tokenId;
+    }
+}

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositErc721Workflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositErc721Workflow.kt
@@ -9,12 +9,13 @@ import com.immutable.sdk.api.EncodingApi
 import com.immutable.sdk.api.UsersApi
 import com.immutable.sdk.api.model.GetSignableRegistrationResponse
 import com.immutable.sdk.contracts.Core_sol_Core
-import com.immutable.sdk.contracts.IERC20_sol_IERC20
+import com.immutable.sdk.contracts.IERC721_sol_IERC721
+import com.immutable.sdk.contracts.Registration_sol_Registration
 import com.immutable.sdk.extensions.hexRemovePrefix
 import com.immutable.sdk.extensions.hexToByteArray
-import com.immutable.sdk.model.Erc20Asset
-import com.immutable.sdk.model.formatQuantity
-import com.immutable.sdk.workflows.executeDeposit
+import com.immutable.sdk.model.Erc721Asset
+import com.immutable.sdk.workflows.executeDepositToken
+import com.immutable.sdk.workflows.executeRegisterAndDepositToken
 import com.immutable.sdk.workflows.prepareDeposit
 import com.immutable.sdk.workflows.sendTransaction
 import org.web3j.protocol.Web3j
@@ -25,10 +26,10 @@ import org.web3j.tx.gas.DefaultGasProvider
 import java.util.concurrent.CompletableFuture
 
 @Suppress("LongParameterList", "LongMethod")
-internal fun depositErc20(
+internal fun depositErc721(
     base: ImmutableXBase,
     nodeUrl: String,
-    token: Erc20Asset,
+    token: Erc721Asset,
     signer: Signer,
     depositsApi: DepositsApi,
     usersApi: UsersApi,
@@ -38,17 +39,24 @@ internal fun depositErc20(
 
     val web3j = Web3j.build(HttpService(nodeUrl))
 
-    approveErc20Token(base, token, web3j, signer)
+    approveErc721Token(base, token, web3j, signer)
         .thenCompose { prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi) }
         .thenCompose { params ->
-            executeDeposit(
-                base,
-                nodeUrl,
-                signer,
-                params,
-                registerAndDepositFunction = Core_sol_Core.FUNC_REGISTERANDDEPOSITERC20,
-                registerAndDepositData = { contract: Core_sol_Core, response: GetSignableRegistrationResponse ->
-                    contract.registerAndDepositERC20(
+            // Using individual execute functions instead of `executeDeposit` since registration contract
+            // is required (instead of core contract) to register and deposit ERC 721 tokens
+            if (!params.isRegistered) executeRegisterAndDepositToken(
+                web3j = web3j,
+                signer = signer,
+                params = params,
+                contract = Registration_sol_Registration.load(
+                    ImmutableConfig.getRegistrationContractAddress(base),
+                    web3j,
+                    ClientTransactionManager(web3j, params.address),
+                    DefaultGasProvider()
+                ),
+                contractFunction = Registration_sol_Registration.FUNC_REGISTERANDDEPOSITNFT,
+                data = { contract: Registration_sol_Registration, response: GetSignableRegistrationResponse ->
+                    contract.registerAndDepositNft(
                         params.address,
                         params.starkKey.hexRemovePrefix().toBigInteger(HEX_RADIX),
                         response.operatorSignature.hexToByteArray(),
@@ -57,16 +65,27 @@ internal fun depositErc20(
                         params.amount
                     ).encodeFunctionCall()
                 },
-                depositFunction = Core_sol_Core.FUNC_DEPOSITERC20,
-                depositData = { contract: Core_sol_Core ->
-                    contract.depositERC20(
+                usersApi = usersApi
+            )
+            else executeDepositToken(
+                web3j = web3j,
+                signer = signer,
+                params = params,
+                contract = Core_sol_Core.load(
+                    ImmutableConfig.getCoreContractAddress(base),
+                    web3j,
+                    ClientTransactionManager(web3j, params.address),
+                    DefaultGasProvider()
+                ),
+                contractFunction = Core_sol_Core.FUNC_DEPOSITNFT,
+                data = { contract: Core_sol_Core ->
+                    contract.depositNft(
                         params.starkKey.hexRemovePrefix().toBigInteger(HEX_RADIX),
                         params.assetType,
                         params.vaultId,
-                        params.amount
+                        token.tokenId.toBigInteger()
                     ).encodeFunctionCall()
-                },
-                usersApi
+                }
             )
         }
         .whenComplete { response, throwable ->
@@ -80,14 +99,14 @@ internal fun depositErc20(
 /**
  * Approve whether an amount of token from an account can be spent by a third-party account
  */
-private fun approveErc20Token(
+private fun approveErc721Token(
     base: ImmutableXBase,
-    token: Erc20Asset,
+    token: Erc721Asset,
     web3j: Web3j,
     signer: Signer
 ): CompletableFuture<EthSendTransaction> = signer.getAddress()
     .thenCompose { address ->
-        val contract = IERC20_sol_IERC20.load(
+        val contract = IERC721_sol_IERC721.load(
             token.tokenAddress,
             web3j,
             ClientTransactionManager(web3j, address),
@@ -96,10 +115,10 @@ private fun approveErc20Token(
 
         sendTransaction(
             contract = contract,
-            contractFunction = IERC20_sol_IERC20.FUNC_APPROVE,
+            contractFunction = IERC721_sol_IERC721.FUNC_APPROVE,
             data = contract.approve(
                 ImmutableConfig.getCoreContractAddress(base),
-                token.formatQuantity().toBigInteger()
+                token.tokenId.toBigInteger()
             ).encodeFunctionCall(),
             signer = signer,
             web3j = web3j

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositEthWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositEthWorkflow.kt
@@ -46,7 +46,7 @@ internal fun depositEth(
                 },
                 depositFunction = Core_sol_Core.FUNC_DEPOSITETH,
                 depositData = { contract: Core_sol_Core ->
-                    contract.deposit(
+                    contract.depositEth(
                         params.starkKey.hexRemovePrefix().toBigInteger(HEX_RADIX),
                         params.assetType,
                         params.vaultId


### PR DESCRIPTION
* Added IERC721 smart contract
* Added auto generated IERC721 wrapper
* Deposit ERC721 workflow
* Refactored `executeDeposit` function
  * Separated "register and deposit" and 'deposit' into two functions 
  * This is because to "register and deposit" ERC721, **registration** contact is required instead of the **core** contract
* Updated deposit ETH workflow to use `depositEth` contract function instead of `deposit` 