### PR TITLE
fix: requests that require a timestamp

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/ImxTimestamp.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/ImxTimestamp.kt
@@ -2,6 +2,8 @@ package com.immutable.sdk.workflows
 
 import com.immutable.sdk.Signer
 import com.immutable.sdk.crypto.Crypto
+import java.time.Clock
+import java.time.Instant
 import java.util.concurrent.CompletableFuture
 
 internal data class ImxTimestamp(val timestamp: String, val signature: String)
@@ -14,10 +16,11 @@ internal data class ImxTimestamp(val timestamp: String, val signature: String)
 
 internal fun <T> imxTimestampRequest(
     signer: Signer,
+    clock: Clock = Clock.systemUTC(),
     performRequest: (ImxTimestamp) -> CompletableFuture<T>
 ): CompletableFuture<T> {
     val future = CompletableFuture<T>()
-    val seconds = System.currentTimeMillis() / 1000L
+    val seconds = Instant.now(clock).epochSecond
     signer.signMessage(seconds.toString())
         .thenCompose { signature ->
             performRequest(ImxTimestamp(seconds.toString(), Crypto.serialiseEthSignature(signature)))

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/ImxTimestamp.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/ImxTimestamp.kt
@@ -3,7 +3,6 @@ package com.immutable.sdk.workflows
 import com.immutable.sdk.Signer
 import com.immutable.sdk.crypto.Crypto
 import java.util.concurrent.CompletableFuture
-import kotlin.math.floor
 
 internal data class ImxTimestamp(val timestamp: String, val signature: String)
 
@@ -19,7 +18,7 @@ internal fun <T> imxTimestampRequest(
 ): CompletableFuture<T> {
     val future = CompletableFuture<T>()
     val seconds = System.currentTimeMillis() / 1000L
-    signer.signMessage(floor(seconds.toDouble()).toString())
+    signer.signMessage(seconds.toString())
         .thenCompose { signature ->
             performRequest(ImxTimestamp(seconds.toString(), Crypto.serialiseEthSignature(signature)))
         }

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/ImxTimestampTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/ImxTimestampTest.kt
@@ -1,0 +1,47 @@
+package com.immutable.sdk.workflows
+
+import com.immutable.sdk.Signer
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.unmockkAll
+import junit.framework.TestCase.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.CompletableFuture
+
+private const val SIGNATURE = "0xc5b53280e17b53d130eed7f00fc4270c29910fc30445af60dbb6abd82dc98f5923fb2fa2" +
+    "a8940c1d6d871c984f19954d25d913857e798d0c8f3fe98b57e7bcb61c"
+private const val SERIALIZED_SIGNATURE = "0xc5b53280e17b53d130eed7f00fc4270c29910fc30445af60dbb6abd82dc98f5923fb2fa2" +
+    "a8940c1d6d871c984f19954d25d913857e798d0c8f3fe98b57e7bcb601"
+
+class ImxTimestampTest {
+    @MockK
+    private lateinit var signer: Signer
+
+    private val clock = Clock.fixed(Instant.parse("2016-01-23T12:34:56Z"), ZoneOffset.UTC)
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun testImxTimestampRequest() {
+        every { signer.signMessage("1453552496") } returns CompletableFuture.completedFuture(SIGNATURE)
+        val future = imxTimestampRequest(signer, clock) { timestamp ->
+            CompletableFuture.completedFuture(timestamp)
+        }.get()
+        assertEquals("1453552496", future.timestamp)
+        assertEquals(SERIALIZED_SIGNATURE, future.signature)
+    }
+}


### PR DESCRIPTION
Fix signing an incorrect representation of the timestamp for authorised requests.

The message to be signed needs to be a recent timestamp formatted in seconds. 