### PR TITLE
feat: add generateStarkPrivateKey method

### DIFF
--- a/imx-core-sdk-kotlin-jvm/build.gradle
+++ b/imx-core-sdk-kotlin-jvm/build.gradle
@@ -259,6 +259,7 @@ tasks.create(name: "testCoverage", type: JacocoReport, dependsOn: ["test"]) {
             '**/*$Result$*.*',
             // Auto-generated code
             '**/com/immutable/sdk/api/**',
+            '**/com/immutable/sdk/contracts/**',
             '**/org/openapitools/**',
             'test/**'
     ]

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Constants.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Constants.kt
@@ -1,8 +1,6 @@
 package com.immutable.sdk
 
 internal object Constants {
-    const val STARK_MESSAGE =
-        "Only sign this request if you’ve initiated an action with Immutable X."
     const val STARK_KEY_PUBLIC_BYTE_LENGTH = 32
 
     const val HEX_PREFIX = "0x"
@@ -13,6 +11,5 @@ internal object Constants {
 
     const val ERC721_AMOUNT = "1"
 
-    const val DEFAULT_CHROME_CUSTOM_TAB_ADDRESS_BAR_COLOUR = "#191E2B"
     const val DEFAULT_MOONPAY_COLOUR_CODE = "#00818e"
 }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/StandardStarkSigner.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/StandardStarkSigner.kt
@@ -1,6 +1,7 @@
 package com.immutable.sdk
 
 import com.google.common.annotations.VisibleForTesting
+import com.immutable.sdk.crypto.StarkCurve
 import com.immutable.sdk.crypto.StarkKey
 import com.immutable.sdk.extensions.getStarkPublicKey
 import org.web3j.crypto.ECKeyPair
@@ -8,8 +9,12 @@ import java.util.concurrent.CompletableFuture
 
 /**
  * A simple implementation of [StarkSigner] that holds the [ECKeyPair] in memory.
+ *
+ * @param privateKey represented in hex format without the prefix "0x"
  */
-class StandardStarkSigner(@VisibleForTesting internal val keyPair: ECKeyPair) : StarkSigner {
+class StandardStarkSigner(privateKey: String) : StarkSigner {
+    @VisibleForTesting internal val keyPair: ECKeyPair = StarkCurve.getKeyPair(privateKey)
+
     override fun getAddress(): CompletableFuture<String> {
         return CompletableFuture.supplyAsync { keyPair.getStarkPublicKey() }
     }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkCurve.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkCurve.kt
@@ -1,12 +1,16 @@
 package com.immutable.sdk.crypto
 
 import com.immutable.sdk.Constants
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import org.bouncycastle.crypto.generators.ECKeyPairGenerator
 import org.bouncycastle.crypto.params.ECDomainParameters
+import org.bouncycastle.crypto.params.ECKeyGenerationParameters
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters
 import org.bouncycastle.math.ec.ECCurve
 import org.bouncycastle.math.ec.ECPoint
 import org.web3j.crypto.ECKeyPair
 import java.math.BigInteger
+import java.security.SecureRandom
 
 // Curve parameters
 private val p = BigInteger(
@@ -73,5 +77,28 @@ internal object StarkCurve {
             BigInteger(privateKey, Constants.HEX_RADIX),
             pubKey
         )
+    }
+
+    @Suppress("MagicNumber")
+    fun generatePrivateKey(): ByteArray {
+        var length: Int
+        var privateKeyBytes: ByteArray
+        do {
+            val gen = ECKeyPairGenerator()
+            val ecParams = ECDomainParameters(
+                curve,
+                curve.createPoint(pointG.xCoord.toBigInteger(), pointG.yCoord.toBigInteger()),
+                N
+            )
+
+            val secureRandom = SecureRandom()
+            val keyGenParam = ECKeyGenerationParameters(ecParams, secureRandom)
+            gen.init(keyGenParam)
+            val kp: AsymmetricCipherKeyPair = gen.generateKeyPair()
+            val privateKey = kp.private as ECPrivateKeyParameters
+            privateKeyBytes = privateKey.d.toByteArray()
+            length = privateKey.d.toByteArray().size
+        } while (length != 32)
+        return privateKeyBytes
     }
 }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
@@ -2,25 +2,16 @@ package com.immutable.sdk.crypto
 
 import com.google.common.annotations.VisibleForTesting
 import com.immutable.sdk.Constants
-import com.immutable.sdk.ImmutableException
-import com.immutable.sdk.Signer
 import com.immutable.sdk.extensions.*
 import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.crypto.signers.ECDSASigner
 import org.bouncycastle.crypto.signers.HMacDSAKCalculator
 import org.bouncycastle.util.BigIntegers
-import org.web3j.crypto.Bip32ECKeyPair
 import org.web3j.crypto.ECDSASignature
 import org.web3j.crypto.ECKeyPair
 import java.math.BigInteger
 import java.security.MessageDigest
-import java.util.concurrent.CompletableFuture
 
-private const val LAYER = "starkex"
-private const val APPLICATION = "immutablex"
-private const val ACCOUNT_PATH = "m/2645'/%d'/%d'/%d'/%d'/1"
-
-private const val HARDENED_BIT = 0x80000000.toInt()
 private val ORDER = BigInteger(
     "0800000000000010ffffffffffffffffb781126dcae7b2321e66a241adc64d2f",
     Constants.HEX_RADIX,
@@ -30,7 +21,6 @@ private val SECP_ORDER = BigInteger(
     Constants.HEX_RADIX,
 )
 private const val SHA_256 = "SHA-256"
-private const val GENERATE_ERROR_MESSAGE = "Failed to generate Stark key pair"
 
 /**
  * An object to generate a Stark key pair from a given Ethereum signer
@@ -45,43 +35,6 @@ object StarkKey {
     internal fun hashSha256(input: ByteArray) = MessageDigest.getInstance(SHA_256).run {
         update(input)
         digest().toHexString("")
-    }
-
-    /**
-     * Grabs the bits from [startFromEnd] to [endFromEnd] in [hex] amd returns
-     * the integer representation of it.
-     *
-     * If [endFromEnd] is null, this function will grab all the bits from [startFromEnd] to the last bit.
-     */
-    internal fun getIntFromBits(
-        hex: String,
-        startFromEnd: Int,
-        endFromEnd: Int? = null,
-    ): Int {
-        val bin = hex.hexToBinary()
-        val bits = if (endFromEnd == null) {
-            bin.takeLast(startFromEnd)
-        } else {
-            val start = bin.length - startFromEnd
-            val end = bin.length - endFromEnd
-            bin.substring(start, end)
-        }
-        return Integer.parseInt(bits, 2)
-    }
-
-    /**
-     * @return StarkEx and ImmutableX account path from the [ethereumAddress]
-     */
-    @Suppress("MagicNumber")
-    @VisibleForTesting
-    internal fun getAccountPath(ethereumAddress: String): String {
-        val layerHash = hashSha256(LAYER.toByteArray())
-        val applicationHash = hashSha256(APPLICATION.toByteArray())
-        val layerInt = getIntFromBits(layerHash, startFromEnd = 31)
-        val applicationInt = getIntFromBits(applicationHash, startFromEnd = 31)
-        val ethAddressInt1 = getIntFromBits(ethereumAddress.substring(2), 31)
-        val ethAddressInt2 = getIntFromBits(ethereumAddress.substring(2), 62, 31)
-        return String.format(ACCOUNT_PATH, layerInt, applicationInt, ethAddressInt1, ethAddressInt2)
     }
 
     /**
@@ -104,46 +57,6 @@ object StarkKey {
             i++
         }
         return key.mod(ORDER).toString(Constants.HEX_RADIX)
-    }
-
-    /**
-     * Generates the Stark key pair from the [seed] and [path]
-     */
-    private fun getKeyPairFromPath(seed: String, path: String): ECKeyPair {
-        val master =
-            Bip32ECKeyPair.generateKeyPair(BigInteger(seed, Constants.HEX_RADIX).toByteArray())
-        val pathArray =
-            path.split("/") // Example: "m/2645'/579218131'/211006541'/9971226311'/947333111'/1"
-        val p = pathArray
-            .subList(1, pathArray.size) // Ignore the first one
-            .map {
-                val isHardened = it.endsWith("'")
-                it
-                    .replace("'", "") // Remove hardened notation
-                    .toInt() // Convert string to int
-                    .run {
-                        if (isHardened) this or HARDENED_BIT else this
-                    }
-            }.toIntArray()
-        val gk = grindKey(
-            Bip32ECKeyPair.deriveKeyPair(master, p)
-                .privateKeyBytes33.drop(1).toHexString()
-        )
-        return StarkCurve.getKeyPair(gk)
-    }
-
-    /**
-     * @param signature the 's' variable of the signature
-     * @param ethereumAddress the connected wallet address
-     * @return Stark key pair
-     */
-    @Suppress("MagicNumber")
-    internal fun getKeyFromRawSignature(signature: String?, ethereumAddress: String?): ECKeyPair? {
-        return if (signature != null && ethereumAddress != null) {
-            val bytes = signature.hexToByteArray()
-            val s = bytes.copyOfRange(32, 64).toNoPrefixHexString()
-            getKeyPairFromPath(s, getAccountPath(ethereumAddress))
-        } else null
     }
 
     /**
@@ -172,33 +85,12 @@ object StarkKey {
     }
 
     /**
-     * Generate a Stark key pair from a L1 wallet.
+     * Generates a new Stark key pair
      */
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    fun generate(signer: Signer): CompletableFuture<ECKeyPair> {
-        return signer.getAddress()
-            .thenCompose { address ->
-                signer.signMessage(Constants.STARK_MESSAGE).thenApply { address to it }
-            }
-            .thenCompose { (address, signature) ->
-                val keyPairFuture = CompletableFuture<ECKeyPair>()
-                CompletableFuture.runAsync {
-                    try {
-                        val keyPair = getKeyFromRawSignature(signature, address)
-                        if (keyPair == null)
-                            keyPairFuture.completeExceptionally(
-                                ImmutableException.clientError(GENERATE_ERROR_MESSAGE)
-                            )
-                        else
-                            keyPairFuture.complete(keyPair)
-                    } catch (e: Exception) {
-                        keyPairFuture.completeExceptionally(
-                            ImmutableException.clientError(GENERATE_ERROR_MESSAGE)
-                        )
-                    }
-                }
-                keyPairFuture
-            }
+    @Suppress("MagicNumber")
+    fun generateStarkPrivateKey(): String {
+        val privateKey = StarkCurve.generatePrivateKey()
+        return StarkCurve.getKeyPair(grindKey(privateKey.toHexString())).privateKey.toByteArray().toNoPrefixHexString()
     }
 
     /**

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/extensions/Web3j.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/extensions/Web3j.kt
@@ -7,7 +7,7 @@ import java.math.BigInteger
 /**
  * @return nonce for the given [address]
  */
-fun Web3j.getNonce(address: String): BigInteger {
+internal fun Web3j.getNonce(address: String): BigInteger {
     val ethGetTransactionCount = ethGetTransactionCount(
         address, DefaultBlockParameterName.PENDING
     ).sendAsync().get()

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/StandardStarkSignerTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/StandardStarkSignerTest.kt
@@ -1,37 +1,43 @@
 package com.immutable.sdk
 
 import com.immutable.sdk.crypto.StarkKey
-import io.mockk.MockKAnnotations
-import io.mockk.every
-import io.mockk.mockkObject
+import com.immutable.sdk.extensions.getStarkPublicKey
+import com.immutable.sdk.extensions.toNoPrefixHexString
+import io.mockk.*
 import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.web3j.crypto.ECKeyPair
-import java.math.BigInteger
+
+private const val STARK_PRIVATE_KEY = "0520a33a1c3bbdbf4c180fe810269eb4b0169b816c8fdde688d415c53ccc0d0c"
+private const val STARK_PUBLIC_ADDRESS = "0x0752ff93fa18f10f3a564e5ba3a2ba7078a59500817a0e5aedbfe1f35bd888e5"
 
 class StandardStarkSignerTest {
     private lateinit var starkSigner: StandardStarkSigner
-    private val keyPair = ECKeyPair(BigInteger.ONE, BigInteger.TEN)
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
 
-        starkSigner = StandardStarkSigner(keyPair)
+        starkSigner = StandardStarkSigner(STARK_PRIVATE_KEY)
+    }
+
+    @Test
+    fun testKeyPairInitialisation() {
+        assertEquals(STARK_PRIVATE_KEY, starkSigner.keyPair.privateKey.toByteArray().toNoPrefixHexString())
+        assertEquals(STARK_PUBLIC_ADDRESS, starkSigner.keyPair.getStarkPublicKey())
     }
 
     @Test
     fun testStarkSignSuccess() {
         mockkObject(StarkKey)
-        every { StarkKey.sign(keyPair, "Sign this") } returns "result"
+        every { StarkKey.sign(starkSigner.keyPair, "Sign this") } returns "result"
         assertEquals("result", starkSigner.signMessage("Sign this").get())
     }
 
     @Test(expected = Exception::class)
     fun testStarkSignError() {
         mockkObject(StarkKey)
-        every { StarkKey.sign(keyPair, "Sign this") } throws Exception()
+        every { StarkKey.sign(any(), "Sign this") } throws Exception()
         starkSigner.signMessage("Sign this").get()
     }
 }

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
@@ -1,84 +1,12 @@
 package com.immutable.sdk.crypto
 
 import com.immutable.sdk.*
-import com.immutable.sdk.extensions.getStarkPublicKey
-import com.immutable.sdk.extensions.toHexString
-import com.immutable.sdk.workflows.SIGNATURE
-import io.mockk.MockKAnnotations
-import io.mockk.every
-import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Test
 import org.web3j.crypto.ECKeyPair
 import java.math.BigInteger
-import java.util.concurrent.CompletableFuture
 
 class StarkKeyTest {
-    @MockK
-    lateinit var signer: Signer
-
-    @Before
-    fun setUp() {
-        MockKAnnotations.init(this)
-    }
-
-    @Test
-    fun testGetAccountPath() {
-        val path = StarkKey.getAccountPath("0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f")
-        assertEquals("m/2645'/579218131'/211006541'/1534045311'/1431804530'/1", path)
-    }
-
-    @Test
-    fun testGetKeyFromRawSignature() {
-        val signature =
-            "0x5a263fad6f17f23e7c7ea833d058f3656d3fe464baf13f6f5ccba9a2466ba2ce4c4a250231bcac" +
-                "7beb165aec4c9b049b4ba40ad8dd287dc79b92b1ffcf20cdcf1b"
-        val ethAddress = "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f"
-        val keypair = StarkKey.getKeyFromRawSignature(
-            signature = signature,
-            ethereumAddress = ethAddress
-        )
-        assertEquals(
-            "0x02a4c7332c55d6c1c510d24272d1db82878f2302f05b53bcc38695ed5f78fffd",
-            keypair?.publicKey?.toByteArray()?.toHexString(
-                byteLength = Constants.STARK_KEY_PUBLIC_BYTE_LENGTH
-            )
-        )
-
-        assertNull(StarkKey.getKeyFromRawSignature(null, null))
-        assertNull(StarkKey.getKeyFromRawSignature(signature, null))
-        assertNull(StarkKey.getKeyFromRawSignature(null, ethAddress))
-    }
-
-    @Test
-    fun testGetKeyFromRawSignatureWithExtraGrinding() {
-        // The signature below requires extra grinding to generate the keys
-        val signature =
-            "0x6d1550458c7a9a1257d73adbcf0fabc12f4497e970d9fa62dd88bf7d9e1271914" +
-                "8c96225c1402d8707fd061b1aae2222bdf13571dfc82b3aa9974039f247f2b81b"
-        val ethAddress = "0xa4864d977b944315389d1765ffa7e66F74ee8cd7"
-        val keypair = StarkKey.getKeyFromRawSignature(
-            signature = signature,
-            ethereumAddress = ethAddress
-        )
-
-        assertEquals(
-            "0x035919acd61e97b3ecdc75ff8beed8d1803f7ea3cad2937926ae59cc3f8070d4",
-            keypair?.getStarkPublicKey()
-        )
-    }
-
-    @Test
-    fun testGetIntFromBits() {
-        // binary representation: 00010010001101001010011001001001101111111101100001001111111101000101001000100010
-        val hex = "1234a649bfd84ff45222"
-        assertEquals(34, StarkKey.getIntFromBits(hex, 9)) // 000100010
-        assertEquals(1_024_657, StarkKey.getIntFromBits(hex, 25, 5)) // 11111010001010010001
-    }
-
     @Test
     fun testHashSha256Update() {
         assertEquals(
@@ -122,97 +50,6 @@ class StarkKeyTest {
             StarkKey.fixMessage(
                 "074180eaec7e68712b5a0fbf5d63a70c33940c9b02e60565e36f84d705b669e"
             )
-        )
-    }
-
-    @Test
-    fun testGenerateSuccess() {
-        val addressFuture = CompletableFuture<String>()
-        val signatureFuture = CompletableFuture<String>()
-        every { signer.getAddress() } returns addressFuture
-        every { signer.signMessage(Constants.STARK_MESSAGE) } returns signatureFuture
-
-        val signature =
-            "0x5a263fad6f17f23e7c7ea833d058f3656d3fe464baf13f6f5ccba9a2466ba2ce4c4a250231bcac" +
-                "7beb165aec4c9b049b4ba40ad8dd287dc79b92b1ffcf20cdcf1b"
-        addressFuture.complete("0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f")
-        signatureFuture.complete(signature)
-
-        testFuture(
-            future = StarkKey.generate(signer)
-        ) { ecKeyPair, throwable ->
-            assert(ecKeyPair != null)
-            assert(throwable == null)
-        }
-    }
-
-    @Test
-    fun testGenerateFailedOnGetAddress() {
-        val addressFuture = CompletableFuture<String>()
-        val signatureFuture = CompletableFuture<String>()
-        every { signer.getAddress() } returns addressFuture
-        every { signer.signMessage(Constants.STARK_MESSAGE) } returns signatureFuture
-
-        addressFuture.completeExceptionally(TestException())
-
-        testFuture(
-            future = StarkKey.generate(signer),
-            expectedResult = null,
-            expectedError = TestException()
-        )
-    }
-
-    @Test
-    fun testGenerateFailedOnSignMessage() {
-        val addressFuture = CompletableFuture<String>()
-        val signatureFuture = CompletableFuture<String>()
-        every { signer.getAddress() } returns addressFuture
-        every { signer.signMessage(Constants.STARK_MESSAGE) } returns signatureFuture
-
-        addressFuture.complete("5")
-        signatureFuture.completeExceptionally(TestException())
-
-        testFuture(
-            future = StarkKey.generate(signer),
-            expectedResult = null,
-            expectedError = TestException()
-        )
-    }
-
-    @Test
-    fun testGenerateFailedInvalidAddress() {
-        val addressFuture = CompletableFuture<String>()
-        val signatureFuture = CompletableFuture<String>()
-        every { signer.getAddress() } returns addressFuture
-        every { signer.signMessage(Constants.STARK_MESSAGE) } returns signatureFuture
-
-        // invalid argument
-        addressFuture.complete("5")
-        signatureFuture.complete(SIGNATURE)
-
-        testFuture(
-            future = StarkKey.generate(signer),
-            expectedResult = null,
-            expectedError = ImmutableException.clientError("")
-        )
-    }
-
-    @Test
-    fun testGenerateFailedInvalidSignature() {
-        val signer = mockk<Signer>()
-        val addressFuture = CompletableFuture<String>()
-        val signatureFuture = CompletableFuture<String>()
-        every { signer.getAddress() } returns addressFuture
-        every { signer.signMessage(Constants.STARK_MESSAGE) } returns signatureFuture
-
-        addressFuture.complete("0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f")
-        // invalid argument
-        signatureFuture.complete("5")
-
-        testFuture(
-            future = StarkKey.generate(signer),
-            expectedResult = null,
-            expectedError = ImmutableException.clientError("")
         )
     }
 }


### PR DESCRIPTION
- Modify `StandardStarkSigner` to take a private key
- Add `StarkKey.generateStarkPrivateKey`
- Removed all key derivation code 
- Changed `Web3j.getNonce` to internal