### PR TITLE
Complete ETH withdrawal

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableX.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/ImmutableX.kt
@@ -121,11 +121,11 @@ class ImmutableX(
      * Deposit based on a token type.
      * For unregistered users, the deposit will be combined with a registration in order to
      * register the user first.
-     * @param signer the L1 signer
      * @param token the token type amount in its corresponding unit
+     * @param signer the L1 signer
      * @returns a [CompletableFuture] that will provide the transaction hash if successful.
      */
-    fun deposit(signer: Signer, token: AssetModel): CompletableFuture<String> {
+    fun deposit(token: AssetModel, signer: Signer): CompletableFuture<String> {
         checkNotNull(nodeUrl) { "nodeUrl cannot be null" }
         return com.immutable.sdk.workflows.deposit(
             base,
@@ -721,8 +721,9 @@ class ImmutableX(
 
     /**
      * Create a Withdrawal
-     * @param signer the L1 signer
      * @param token the token type amount in its corresponding unit
+     * @param signer the L1 signer
+     * @param starkSigner represents the users L2 wallet used to sign and verify the L2 transaction
      * @returns a [CompletableFuture] that will provide the transaction hash if successful.
      */
     fun prepareWithdrawal(
@@ -736,6 +737,26 @@ class ImmutableX(
             starkSigner,
             withdrawalsApi
         )
+
+    /**
+     * Completes a Withdrawal
+     * @param token the token
+     * @param signer the L1 signer
+     * @param starkPublicKey the L2 stark public key
+     * @returns a [CompletableFuture] that will provide the transaction hash if successful.
+     */
+    fun completeWithdrawal(token: AssetModel, signer: Signer, starkPublicKey: String): CompletableFuture<String> {
+        checkNotNull(nodeUrl) { "nodeUrl cannot be null" }
+        return com.immutable.sdk.workflows.completeWithdrawal(
+            base,
+            nodeUrl,
+            token,
+            signer,
+            starkPublicKey,
+            usersApi,
+            encodingApi
+        )
+    }
 
     /**
      * Get details of an order with the given ID

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/DepositWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/DepositWorkflow.kt
@@ -1,6 +1,5 @@
 package com.immutable.sdk.workflows
 
-import com.google.common.annotations.VisibleForTesting
 import com.immutable.sdk.ImmutableConfig.getCoreContractAddress
 import com.immutable.sdk.ImmutableXBase
 import com.immutable.sdk.Signer
@@ -24,8 +23,6 @@ import java.math.BigInteger
 import java.util.concurrent.CompletableFuture
 
 private const val GET_SIGNABLE_DEPOSIT = "Get signable deposit"
-private const val ENCODE_ASSET = "Encode asset"
-@VisibleForTesting internal const val ENCODE_ASSET_TYPE = "asset"
 
 @Suppress("LongParameterList")
 internal fun deposit(
@@ -103,32 +100,6 @@ private fun getSignableDeposit(
             user = address
         )
     )
-}
-
-private fun encodeAsset(
-    asset: AssetModel,
-    api: EncodingApi,
-) = call(ENCODE_ASSET) {
-    val tokenType = when (asset) {
-        is EthAsset -> EncodeAssetRequestToken.Type.eTH
-        is Erc20Asset -> EncodeAssetRequestToken.Type.eRC20
-        is Erc721Asset -> EncodeAssetRequestToken.Type.eRC721
-    }
-    val encodeAssetTokenData = when (asset) {
-        is EthAsset -> null
-        is Erc20Asset -> EncodeAssetTokenData(tokenAddress = asset.tokenAddress)
-        is Erc721Asset -> EncodeAssetTokenData(
-            tokenAddress = asset.tokenAddress,
-            tokenId = asset.tokenId
-        )
-    }
-    val request = EncodeAssetRequest(
-        token = EncodeAssetRequestToken(
-            type = tokenType,
-            data = encodeAssetTokenData
-        )
-    )
-    api.encodeAsset(ENCODE_ASSET_TYPE, request)
 }
 
 @Suppress("LongParameterList")

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/EncodeAsset.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/EncodeAsset.kt
@@ -1,0 +1,41 @@
+package com.immutable.sdk.workflows
+
+import com.google.common.annotations.VisibleForTesting
+import com.immutable.sdk.api.EncodingApi
+import com.immutable.sdk.api.model.EncodeAssetRequest
+import com.immutable.sdk.api.model.EncodeAssetRequestToken
+import com.immutable.sdk.api.model.EncodeAssetTokenData
+import com.immutable.sdk.model.AssetModel
+import com.immutable.sdk.model.Erc20Asset
+import com.immutable.sdk.model.Erc721Asset
+import com.immutable.sdk.model.EthAsset
+
+private const val ENCODE_ASSET = "Encode asset"
+@VisibleForTesting
+internal const val ENCODE_ASSET_TYPE = "asset"
+
+internal fun encodeAsset(
+    asset: AssetModel,
+    api: EncodingApi,
+) = call(ENCODE_ASSET) {
+    val tokenType = when (asset) {
+        is EthAsset -> EncodeAssetRequestToken.Type.eTH
+        is Erc20Asset -> EncodeAssetRequestToken.Type.eRC20
+        is Erc721Asset -> EncodeAssetRequestToken.Type.eRC721
+    }
+    val encodeAssetTokenData = when (asset) {
+        is EthAsset -> null
+        is Erc20Asset -> EncodeAssetTokenData(tokenAddress = asset.tokenAddress)
+        is Erc721Asset -> EncodeAssetTokenData(
+            tokenAddress = asset.tokenAddress,
+            tokenId = asset.tokenId
+        )
+    }
+    val request = EncodeAssetRequest(
+        token = EncodeAssetRequestToken(
+            type = tokenType,
+            data = encodeAssetTokenData
+        )
+    )
+    api.encodeAsset(ENCODE_ASSET_TYPE, request)
+}

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/RegisterWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/RegisterWorkflow.kt
@@ -22,6 +22,7 @@ private const val REGISTER_USER = "Register user"
 private const val SIGNABLE_REGISTRATION = "Signable registration"
 private const val SIGNABLE_REGISTRATION_ON_CHAIN = "Get signable registration on-chain"
 private const val GET_STARK_KEY = "Get stark key"
+internal const val USER_UNREGISTERED = "USER_UNREGISTERED"
 
 private data class RegisterData(
     val address: String = "",
@@ -157,7 +158,7 @@ internal fun isRegisteredOnChain(
                 .sendAsync()
         }
         .whenComplete { response, error ->
-            if (error?.message?.contains("USER_UNREGISTERED") == true)
+            if (error?.message?.contains(USER_UNREGISTERED) == true)
                 future.complete(false)
             else if (error != null) // Forward exceptions
                 future.completeExceptionally(error)

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/TransferWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/TransferWorkflow.kt
@@ -6,6 +6,7 @@ import com.immutable.sdk.api.TransfersApi
 import com.immutable.sdk.api.model.*
 import com.immutable.sdk.crypto.Crypto
 import com.immutable.sdk.model.AssetModel
+import com.immutable.sdk.model.formatQuantity
 import java.util.concurrent.CompletableFuture
 
 private const val GET_SIGNABLE_TRANSFER = "Get signable transfer"
@@ -66,7 +67,7 @@ private fun getSignableTransfer(
         senderEtherKey = address,
         signableRequests = transfers.map { data ->
             SignableTransferDetails(
-                amount = data.token.quantity,
+                amount = data.token.formatQuantity(),
                 receiver = data.recipientAddress,
                 token = data.token.toSignableToken()
             )

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflow.kt
@@ -1,0 +1,181 @@
+package com.immutable.sdk.workflows
+
+import com.immutable.sdk.ImmutableConfig
+import com.immutable.sdk.ImmutableXBase
+import com.immutable.sdk.Signer
+import com.immutable.sdk.api.EncodingApi
+import com.immutable.sdk.api.UsersApi
+import com.immutable.sdk.api.model.GetSignableRegistrationResponse
+import com.immutable.sdk.contracts.Core_sol_Core
+import com.immutable.sdk.contracts.Registration_sol_Registration
+import com.immutable.sdk.model.*
+import com.immutable.sdk.workflows.withdrawal.completeEthWithdrawal
+import org.web3j.protocol.Web3j
+import org.web3j.protocol.core.methods.response.EthSendTransaction
+import org.web3j.protocol.http.HttpService
+import org.web3j.tx.ClientTransactionManager
+import org.web3j.tx.gas.DefaultGasProvider
+import org.web3j.utils.Convert
+import java.math.BigInteger
+import java.util.concurrent.CompletableFuture
+
+@Suppress("LongParameterList")
+internal fun completeWithdrawal(
+    base: ImmutableXBase,
+    nodeUrl: String,
+    token: AssetModel,
+    signer: Signer,
+    starkPublicKey: String,
+    usersApi: UsersApi,
+    encodingApi: EncodingApi,
+): CompletableFuture<String> = when (token) {
+    is EthAsset ->
+        completeEthWithdrawal(base, nodeUrl, token, signer, starkPublicKey, usersApi, encodingApi)
+    is Erc20Asset -> CompletableFuture.failedFuture(UnsupportedOperationException())
+    is Erc721Asset -> CompletableFuture.failedFuture(UnsupportedOperationException())
+}
+
+/**
+ * 1. Encodes the [token]
+ * 2. Checks if user is registered on chain
+ *
+ * @return [DepositWorkflowParams]
+ */
+@Suppress("LongParameterList")
+internal fun prepareCompleteWithdrawal(
+    base: ImmutableXBase,
+    nodeUrl: String,
+    token: AssetModel,
+    signer: Signer,
+    starkPublicKey: String,
+    usersApi: UsersApi,
+    encodingApi: EncodingApi
+): CompletableFuture<CompleteWithdrawalWorkflowParams> {
+    val amount = when (token) {
+        is EthAsset -> Convert.toWei(token.quantity, Convert.Unit.ETHER).toBigInteger()
+        is Erc20Asset -> token.formatQuantity().toBigInteger()
+        is Erc721Asset -> BigInteger.ONE
+    }
+
+    return signer.getAddress()
+        .thenCompose { address ->
+            encodeAsset(token, encodingApi).thenApply { encodeAssetResponse ->
+                CompleteWithdrawalWorkflowParams(
+                    tokenType = token.toSignableToken().type,
+                    address = address,
+                    starkKey = starkPublicKey,
+                    assetType = encodeAssetResponse.assetType.toBigInteger(),
+                    amount = amount
+                )
+            }
+        }
+        .thenCompose { params ->
+            isRegisteredOnChain(base, nodeUrl, signer, usersApi)
+                .thenApply { isRegistered -> params.copy(isRegistered = isRegistered) }
+        }
+}
+
+@Suppress("LongParameterList")
+internal fun executeCompleteWithdrawal(
+    base: ImmutableXBase,
+    nodeUrl: String,
+    signer: Signer,
+    params: CompleteWithdrawalWorkflowParams,
+    registerAndWithdrawFunction: String,
+    registerAndWithdrawData: (Registration_sol_Registration, GetSignableRegistrationResponse) -> String,
+    withdrawFunction: String,
+    withdrawData: (Core_sol_Core) -> String,
+    usersApi: UsersApi
+): CompletableFuture<EthSendTransaction> {
+    val web3j = Web3j.build(HttpService(nodeUrl))
+
+    return if (!params.isRegistered) // User is not registered, do both registration and complete withdrawal
+        executeRegisterAndWithdrawToken(
+            base,
+            web3j,
+            signer,
+            params,
+            registerAndWithdrawFunction,
+            registerAndWithdrawData,
+            usersApi
+        )
+    else // User is already registered, continue to complete withdrawal
+        executeWithdrawToken(
+            base,
+            web3j,
+            signer,
+            params,
+            withdrawFunction,
+            withdrawData
+        )
+}
+
+@Suppress("LongParameterList")
+internal fun executeRegisterAndWithdrawToken(
+    base: ImmutableXBase,
+    web3j: Web3j,
+    signer: Signer,
+    params: CompleteWithdrawalWorkflowParams,
+    contractFunction: String,
+    data: (Registration_sol_Registration, GetSignableRegistrationResponse) -> String,
+    usersApi: UsersApi
+): CompletableFuture<EthSendTransaction> {
+    val contract = Registration_sol_Registration.load(
+        ImmutableConfig.getRegistrationContractAddress(base),
+        web3j,
+        ClientTransactionManager(web3j, params.address),
+        DefaultGasProvider()
+    )
+
+    return signer.getAddress()
+        .thenCompose { address ->
+            getSignableRegistrationOnChain(
+                address,
+                params.starkKey,
+                usersApi
+            )
+        }
+        .thenCompose { response ->
+            sendTransaction(
+                contract = contract,
+                contractFunction = contractFunction,
+                data = data(contract, response),
+                signer = signer,
+                web3j = web3j
+            )
+        }
+}
+
+@Suppress("LongParameterList")
+internal fun executeWithdrawToken(
+    base: ImmutableXBase,
+    web3j: Web3j,
+    signer: Signer,
+    params: CompleteWithdrawalWorkflowParams,
+    contractFunction: String,
+    data: (Core_sol_Core) -> String,
+): CompletableFuture<EthSendTransaction> {
+    val contract = Core_sol_Core.load(
+        ImmutableConfig.getCoreContractAddress(base),
+        web3j,
+        ClientTransactionManager(web3j, params.address),
+        DefaultGasProvider()
+    )
+
+    return sendTransaction(
+        contract = contract,
+        contractFunction = contractFunction,
+        data = data(contract),
+        signer = signer,
+        web3j = web3j
+    )
+}
+
+internal data class CompleteWithdrawalWorkflowParams(
+    val tokenType: String?,
+    val address: String,
+    val starkKey: String,
+    val assetType: BigInteger,
+    val amount: BigInteger,
+    val isRegistered: Boolean = false,
+)

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/Workflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/Workflow.kt
@@ -65,7 +65,11 @@ internal fun sendTransaction(
             )
 
             val signedTransaction = signer.signTransaction(rawTransaction).get()
-            future.complete(web3j.ethSendRawTransaction(signedTransaction).send())
+            val response = web3j.ethSendRawTransaction(signedTransaction).send()
+            if (response.error != null) future.completeExceptionally(
+                ImmutableException.contractError("$contractFunction: ${response.error.message}")
+            )
+            else future.complete(response)
         } catch (e: Exception) {
             future.completeExceptionally(ImmutableException.contractError(contractFunction, e))
         }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/CompleteEthWithdrawalWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/CompleteEthWithdrawalWorkflow.kt
@@ -1,0 +1,64 @@
+package com.immutable.sdk.workflows.withdrawal
+
+import com.immutable.sdk.Constants
+import com.immutable.sdk.ImmutableXBase
+import com.immutable.sdk.Signer
+import com.immutable.sdk.api.EncodingApi
+import com.immutable.sdk.api.UsersApi
+import com.immutable.sdk.api.model.GetSignableRegistrationResponse
+import com.immutable.sdk.contracts.Core_sol_Core
+import com.immutable.sdk.contracts.Registration_sol_Registration
+import com.immutable.sdk.extensions.hexRemovePrefix
+import com.immutable.sdk.extensions.hexToByteArray
+import com.immutable.sdk.model.EthAsset
+import com.immutable.sdk.workflows.executeCompleteWithdrawal
+import com.immutable.sdk.workflows.prepareCompleteWithdrawal
+import java.util.concurrent.CompletableFuture
+
+@Suppress("LongParameterList", "LongMethod")
+internal fun completeEthWithdrawal(
+    base: ImmutableXBase,
+    nodeUrl: String,
+    token: EthAsset,
+    signer: Signer,
+    starkPublicKey: String,
+    usersApi: UsersApi,
+    encodingApi: EncodingApi,
+): CompletableFuture<String> = signer.getAddress()
+    .thenCompose {
+        prepareCompleteWithdrawal(
+            base,
+            nodeUrl,
+            token,
+            signer,
+            starkPublicKey,
+            usersApi,
+            encodingApi
+        )
+    }
+    .thenCompose { params ->
+        executeCompleteWithdrawal(
+            base,
+            nodeUrl,
+            signer,
+            params,
+            registerAndWithdrawFunction = Registration_sol_Registration.FUNC_REGISTERANDWITHDRAW,
+            registerAndWithdrawData = { contract, response: GetSignableRegistrationResponse ->
+                contract.registerAndWithdraw(
+                    params.address,
+                    params.starkKey.hexRemovePrefix().toBigInteger(Constants.HEX_RADIX),
+                    response.operatorSignature.hexToByteArray(),
+                    params.assetType,
+                ).encodeFunctionCall()
+            },
+            withdrawFunction = Core_sol_Core.FUNC_WITHDRAW,
+            withdrawData = { contract ->
+                contract.withdraw(
+                    params.starkKey.hexRemovePrefix().toBigInteger(Constants.HEX_RADIX),
+                    params.assetType,
+                ).encodeFunctionCall()
+            },
+            usersApi
+        )
+    }
+    .thenApply { it.transactionHash }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/PrepareWithdrawalWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/PrepareWithdrawalWorkflow.kt
@@ -10,6 +10,7 @@ import com.immutable.sdk.api.model.GetSignableWithdrawalRequest
 import com.immutable.sdk.api.model.GetSignableWithdrawalResponse
 import com.immutable.sdk.model.AssetModel
 import com.immutable.sdk.model.Erc721Asset
+import com.immutable.sdk.model.formatQuantity
 import com.immutable.sdk.workflows.WorkflowSignatures
 import com.immutable.sdk.workflows.call
 import java.util.concurrent.CompletableFuture
@@ -23,7 +24,7 @@ internal fun prepareWithdrawal(
     starkSigner: StarkSigner,
     withdrawalsApi: WithdrawalsApi
 ): CompletableFuture<CreateWithdrawalResponse> {
-    val amount = if (token is Erc721Asset) ERC721_AMOUNT else token.quantity
+    val amount = if (token is Erc721Asset) ERC721_AMOUNT else token.formatQuantity()
 
     return signer.getAddress()
         .thenApply { address -> WorkflowSignatures(address) }

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/DepositWorkflowTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/DepositWorkflowTest.kt
@@ -47,11 +47,11 @@ private const val OPERATOR_SIGNATURE =
         "7beb165aec4c9b049b4ba40ad8dd287dc79b92b1ffcf20cdcf11"
 private const val PAYLOAD_HASH = "registerPayloadHash"
 private const val NODE_URL = "https://eth-goerli.g.alchemy.com/v2/apiKey"
-const val CORE_CONTRACT_ADDRESS = "0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2123"
-const val REGISTRATION_CONTRACT_ADDRESS = "0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207Dabc"
-const val ERC20_CONTRACT_ADDRESS = "0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2000"
-const val ERC721_CONTRACT_ADDRESS = "0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D111"
-const val ENCODED_FUNCTION_CALL = "000111000554abc00000000a123def000000"
+private const val CORE_CONTRACT_ADDRESS = "0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2123"
+private const val REGISTRATION_CONTRACT_ADDRESS = "0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207Dabc"
+private const val ERC20_CONTRACT_ADDRESS = "0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2000"
+private const val ERC721_CONTRACT_ADDRESS = "0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D111"
+private const val ENCODED_FUNCTION_CALL = "000111000554abc00000000a123def000000"
 private const val SIGNED_TRANSACTION = "0xSignedTransaction"
 private const val TRANSACTION_HASH = "0xTransactionHash"
 private val NONCE = BigInteger.ONE
@@ -131,6 +131,7 @@ class DepositWorkflowTest {
         every { web3j.ethSendRawTransaction(any()) } returns ethSendRequest
         every { ethSendRequest.send() } returns ethSendTransaction
         every { ethSendTransaction.transactionHash } returns TRANSACTION_HASH
+        every { ethSendTransaction.error } returns null
         val transactionCountRequest = mockk<Request<Any, EthGetTransactionCount>>()
         every { web3j.ethGetTransactionCount(any(), any()) } returns transactionCountRequest
         val count = mockk<EthGetTransactionCount>()
@@ -195,7 +196,7 @@ class DepositWorkflowTest {
 
     @Test
     fun testDepositEthSuccess_registerAndDeposit_registeredOffChainUser() {
-        every { registrationContract.isRegistered(any()) } throws Throwable("USER_UNREGISTERED")
+        every { registrationContract.isRegistered(any()) } throws Throwable(USER_UNREGISTERED)
 
         addressFuture.complete(ADDRESS)
         signedTransactionFuture.complete(SIGNED_TRANSACTION)
@@ -332,7 +333,7 @@ class DepositWorkflowTest {
 
     @Test
     fun testDepositErc20Success_registerAndDeposit() {
-        every { registrationContract.isRegistered(any()) } throws Throwable("USER_UNREGISTERED")
+        every { registrationContract.isRegistered(any()) } throws Throwable(USER_UNREGISTERED)
 
         addressFuture.complete(ADDRESS)
         signedTransactionFuture.complete(SIGNED_TRANSACTION)
@@ -428,7 +429,7 @@ class DepositWorkflowTest {
 
     @Test
     fun testDepositErc721Success_registerAndDeposit() {
-        every { registrationContract.isRegistered(any()) } throws Throwable("USER_UNREGISTERED")
+        every { registrationContract.isRegistered(any()) } throws Throwable(USER_UNREGISTERED)
 
         addressFuture.complete(ADDRESS)
         signedTransactionFuture.complete(SIGNED_TRANSACTION)

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflowTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflowTest.kt
@@ -1,0 +1,296 @@
+package com.immutable.sdk.workflows
+
+import com.immutable.sdk.*
+import com.immutable.sdk.api.EncodingApi
+import com.immutable.sdk.api.UsersApi
+import com.immutable.sdk.api.model.*
+import com.immutable.sdk.contracts.Core_sol_Core
+import com.immutable.sdk.contracts.Registration_sol_Registration
+import com.immutable.sdk.extensions.hexToByteArray
+import com.immutable.sdk.model.AssetModel
+import com.immutable.sdk.model.EthAsset
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.openapitools.client.infrastructure.ClientException
+import org.web3j.abi.datatypes.Function
+import org.web3j.protocol.Web3j
+import org.web3j.protocol.core.RemoteFunctionCall
+import org.web3j.protocol.core.Request
+import org.web3j.protocol.core.Response
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount
+import org.web3j.protocol.core.methods.response.EthSendTransaction
+import org.web3j.protocol.core.methods.response.TransactionReceipt
+import org.web3j.protocol.http.HttpService
+import org.web3j.tx.TransactionManager
+import java.io.IOException
+import java.math.BigInteger
+import java.util.concurrent.CompletableFuture
+
+private const val ADDRESS = "0xa76e3eeb2f7143165618ab8feaabcd395b6faaaa"
+private const val AMOUNT = "0.0001"
+private const val ASSET_ID = "5461"
+private const val ASSET_TYPE = "712"
+private const val STARK_KEY = "0x06588251eea34f39848302f991b8bc7098e2bb5fd2eba120255f91e971a23485"
+private val STARK_KEY_BIG_INT =
+    BigInteger("2870259069112366000714388987675960825159149244184363600690019399428626068613")
+private const val OPERATOR_SIGNATURE =
+    "0x5a263fad6f17f23e7c7ea833d058f3656d3fe464baf13f6f5ccba9a2466ba2ce4c4a250231bcac" +
+        "7beb165aec4c9b049b4ba40ad8dd287dc79b92b1ffcf20cdcf11"
+private const val PAYLOAD_HASH = "registerPayloadHash"
+private const val NODE_URL = "https://eth-goerli.g.alchemy.com/v2/apiKey"
+private const val CORE_CONTRACT_ADDRESS = "0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2123"
+private const val REGISTRATION_CONTRACT_ADDRESS = "0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207Dabc"
+private const val ENCODED_FUNCTION_CALL = "000111000554abc00000000a123def000000"
+private const val SIGNED_TRANSACTION = "0xSignedTransaction"
+private const val TRANSACTION_HASH = "0x28ca2abed368dca3f304fbb2be6db1f56cdcb138cdd3a68f86dcbb40ddda7545"
+private val NONCE = BigInteger.ONE
+
+class WithdrawalWorkflowTest {
+    @MockK
+    private lateinit var usersApi: UsersApi
+
+    @MockK
+    private lateinit var encodingApi: EncodingApi
+
+    @MockK
+    private lateinit var signer: Signer
+
+    @MockK
+    private lateinit var web3j: Web3j
+
+    @MockK
+    private lateinit var coreContract: Core_sol_Core
+
+    @MockK
+    private lateinit var registrationContract: Registration_sol_Registration
+
+    @MockK
+    private lateinit var function: Function
+
+    @MockK
+    private lateinit var txRemoteFunctionCall: RemoteFunctionCall<TransactionReceipt>
+
+    @MockK
+    private lateinit var ethSendRequest: Request<Any, EthSendTransaction>
+
+    @MockK
+    private lateinit var ethSendTransaction: EthSendTransaction
+
+    private lateinit var addressFuture: CompletableFuture<String>
+    private lateinit var signedTransactionFuture: CompletableFuture<String>
+
+    @Suppress("LongMethod")
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        addressFuture = CompletableFuture<String>()
+        every { signer.getAddress() } returns addressFuture
+        signedTransactionFuture = CompletableFuture<String>()
+        every { signer.signTransaction(any()) } returns signedTransactionFuture
+
+        every { encodingApi.encodeAsset(any(), any()) } returns EncodeAssetResponse(ASSET_ID, ASSET_TYPE)
+        every { usersApi.getUsers(any()) } returns GetUsersApiResponse(arrayListOf(STARK_KEY))
+        every { usersApi.getSignableRegistration(any()) } returns GetSignableRegistrationResponse(
+            OPERATOR_SIGNATURE, PAYLOAD_HASH
+        )
+
+        mockkObject(ImmutableConfig)
+        every { ImmutableConfig.getRegistrationContractAddress(any()) } returns REGISTRATION_CONTRACT_ADDRESS
+        every { ImmutableConfig.getCoreContractAddress(any()) } returns CORE_CONTRACT_ADDRESS
+
+        mockkStatic(Web3j::class)
+        every { Web3j.build(any<HttpService>()) } returns web3j
+        every { web3j.ethSendRawTransaction(any()) } returns ethSendRequest
+        every { ethSendRequest.send() } returns ethSendTransaction
+        every { ethSendTransaction.transactionHash } returns TRANSACTION_HASH
+        every { ethSendTransaction.error } returns null
+        val transactionCountRequest = mockk<Request<Any, EthGetTransactionCount>>()
+        every { web3j.ethGetTransactionCount(any(), any()) } returns transactionCountRequest
+        val count = mockk<EthGetTransactionCount>()
+        every { transactionCountRequest.sendAsync() } returns CompletableFuture.completedFuture(count)
+        every { count.transactionCount } returns NONCE
+
+        every { txRemoteFunctionCall.encodeFunctionCall() } returns ENCODED_FUNCTION_CALL
+
+        mockkStatic(Registration_sol_Registration::class)
+        every {
+            Registration_sol_Registration.load(any(), any(), any<TransactionManager>(), any())
+        } returns registrationContract
+        every {
+            registrationContract.registerAndWithdraw(any(), any(), any(), any())
+        } returns txRemoteFunctionCall
+        every { registrationContract.contractAddress } returns REGISTRATION_CONTRACT_ADDRESS
+
+        mockkStatic(Core_sol_Core::class)
+        every {
+            Core_sol_Core.load(any(), any(), any<TransactionManager>(), any())
+        } returns coreContract
+        every { coreContract.withdraw(any(), any()) } returns txRemoteFunctionCall
+        every { coreContract.contractAddress } returns CORE_CONTRACT_ADDRESS
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun createCompleteWithdrawalFuture(token: AssetModel) = completeWithdrawal(
+        ImmutableXBase.Sandbox,
+        NODE_URL,
+        token,
+        signer,
+        STARK_KEY,
+        usersApi,
+        encodingApi
+    )
+
+    private fun <T> remoteFunctionCall(value: T) = RemoteFunctionCall(function) { value }
+
+    @Test
+    fun testWithdrawEthSuccess_registerAndWithdraw_registeredOffChainUser() {
+        every { registrationContract.isRegistered(any()) } throws Throwable(USER_UNREGISTERED)
+
+        addressFuture.complete(ADDRESS)
+        signedTransactionFuture.complete(SIGNED_TRANSACTION)
+
+        val token = EthAsset(AMOUNT)
+        testFuture(
+            future = createCompleteWithdrawalFuture(token),
+            expectedResult = TRANSACTION_HASH,
+            expectedError = null
+        )
+
+        verify { signer.getAddress() }
+        verify {
+            encodingApi.encodeAsset(
+                ENCODE_ASSET_TYPE,
+                EncodeAssetRequest(
+                    EncodeAssetRequestToken(type = EncodeAssetRequestToken.Type.eTH, data = null)
+                )
+            )
+        }
+        verify { usersApi.getUsers(ADDRESS) }
+        verify { registrationContract.isRegistered(STARK_KEY_BIG_INT) }
+        verify { usersApi.getSignableRegistration(GetSignableRegistrationRequest(ADDRESS, STARK_KEY)) }
+        verify {
+            registrationContract.registerAndWithdraw(
+                ADDRESS,
+                STARK_KEY_BIG_INT,
+                OPERATOR_SIGNATURE.hexToByteArray(),
+                ASSET_TYPE.toBigInteger()
+            )
+        }
+        verify { signer.signTransaction(any()) }
+        verify { web3j.ethSendRawTransaction(any()) }
+    }
+
+    @Test
+    fun testWithdrawEthSuccess_registerAndWithdraw_NotRegisteredOffChain() {
+        every { usersApi.getUsers(any()) } throws ClientException()
+
+        addressFuture.complete(ADDRESS)
+        signedTransactionFuture.complete(SIGNED_TRANSACTION)
+
+        testFuture(
+            future = createCompleteWithdrawalFuture(EthAsset(AMOUNT)),
+            expectedResult = null,
+            expectedError = ImmutableException.apiError("")
+        )
+    }
+
+    @Test
+    fun testWithdrawEthSuccess_withdraw() {
+        every { registrationContract.isRegistered(any()) } returns remoteFunctionCall(true)
+
+        addressFuture.complete(ADDRESS)
+        signedTransactionFuture.complete(SIGNED_TRANSACTION)
+
+        val token = EthAsset(AMOUNT)
+        testFuture(
+            future = createCompleteWithdrawalFuture(token),
+            expectedResult = TRANSACTION_HASH,
+            expectedError = null
+        )
+
+        verify {
+            encodingApi.encodeAsset(
+                ENCODE_ASSET_TYPE,
+                EncodeAssetRequest(
+                    EncodeAssetRequestToken(type = EncodeAssetRequestToken.Type.eTH, data = null)
+                )
+            )
+        }
+        verify { usersApi.getUsers(ADDRESS) }
+        verify { registrationContract.isRegistered(STARK_KEY_BIG_INT) }
+        verify(exactly = 0) { usersApi.getSignableRegistration(any()) }
+        verify {
+            coreContract.withdraw(
+                STARK_KEY_BIG_INT,
+                ASSET_TYPE.toBigInteger()
+            )
+        }
+        verify { signer.signTransaction(any()) }
+        verify { web3j.ethSendRawTransaction(any()) }
+    }
+
+    @Test
+    fun testWithdraw_getAddressError() {
+        addressFuture.completeExceptionally(TestException())
+
+        testFuture(
+            future = createCompleteWithdrawalFuture(EthAsset(AMOUNT)),
+            expectedResult = null,
+            expectedError = TestException()
+        )
+    }
+
+    @Test
+    fun testWithdraw_encodeAssetError() {
+        every { encodingApi.encodeAsset(any(), any()) } throws ClientException()
+
+        addressFuture.complete(ADDRESS)
+        signedTransactionFuture.complete(SIGNED_TRANSACTION)
+
+        testFuture(
+            future = createCompleteWithdrawalFuture(EthAsset(AMOUNT)),
+            expectedResult = null,
+            expectedError = ImmutableException.apiError("")
+        )
+    }
+
+    @Test
+    fun testWithdraw_sendTransactionError() {
+        every { registrationContract.isRegistered(any()) } returns remoteFunctionCall(true)
+        every { ethSendRequest.send() } throws IOException()
+
+        addressFuture.complete(ADDRESS)
+        signedTransactionFuture.complete(SIGNED_TRANSACTION)
+
+        testFuture(
+            future = createCompleteWithdrawalFuture(EthAsset(AMOUNT)),
+            expectedResult = null,
+            expectedError = ImmutableException.contractError("")
+        )
+    }
+
+    @Test
+    fun testWithdraw_sendTransactionError2() {
+        every { registrationContract.isRegistered(any()) } returns remoteFunctionCall(true)
+        val error = mockk<Response.Error>()
+        every { ethSendTransaction.error } returns error
+        every { error.message } returns ""
+
+        addressFuture.complete(ADDRESS)
+        signedTransactionFuture.complete(SIGNED_TRANSACTION)
+
+        testFuture(
+            future = createCompleteWithdrawalFuture(EthAsset(AMOUNT)),
+            expectedResult = null,
+            expectedError = ImmutableException.contractError("")
+        )
+    }
+}


### PR DESCRIPTION
* Complete ETH withdrawal workflow
* Moved "encode asset" step from `DepositWorkFlow.kt` to a separate file so it can be reused in complete withdrawal workflows
* Refactored hardcoded "UNREGISTERED_USER" to a constant
* Fixed transfer workflow 'amount' and added tests
* Fixed prepare withdrawal workflow 'amount' and added tests
* When sending a transaction, check for errors (`Workflow.kt`)