### PR TITLE
feat: withdraw ERC20

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/CancelWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/CancelWorkflow.kt
@@ -16,9 +16,7 @@ internal fun cancelOrder(
     signer: Signer,
     starkSigner: StarkSigner,
     ordersApi: OrdersApi = OrdersApi()
-): CompletableFuture<CancelOrderResponse> {
-    val future = CompletableFuture<CancelOrderResponse>()
-
+): CompletableFuture<CancelOrderResponse> =
     signer.getAddress().thenApply { address -> WorkflowSignatures(address) }
         .thenCompose { signatures ->
             getSignableCancelOrder(orderId, ordersApi).thenApply { response -> signatures to response }
@@ -32,16 +30,6 @@ internal fun cancelOrder(
                 .thenApply { signature -> signatures.apply { ethSignature = signature } }
         }
         .thenCompose { signatures -> cancelOrder(orderId, signatures, ordersApi) }
-        .whenComplete { response, error ->
-            // Forward any exceptions from the compose chain
-            if (error != null)
-                future.completeExceptionally(error)
-            else
-                future.complete(response)
-        }
-
-    return future
-}
 
 private fun getSignableCancelOrder(orderId: String, api: OrdersApi) = call(SIGNABLE_CANCEL_ORDER) {
     api.getSignableCancelOrder(GetSignableCancelOrderRequest(orderId = orderId.toInt()))

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/ImxTimestamp.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/ImxTimestamp.kt
@@ -19,17 +19,9 @@ internal fun <T> imxTimestampRequest(
     clock: Clock = Clock.systemUTC(),
     performRequest: (ImxTimestamp) -> CompletableFuture<T>
 ): CompletableFuture<T> {
-    val future = CompletableFuture<T>()
     val seconds = Instant.now(clock).epochSecond
-    signer.signMessage(seconds.toString())
+    return signer.signMessage(seconds.toString())
         .thenCompose { signature ->
             performRequest(ImxTimestamp(seconds.toString(), Crypto.serialiseEthSignature(signature)))
         }
-        .whenComplete { collection, throwable ->
-            if (throwable != null)
-                future.completeExceptionally(throwable)
-            else
-                future.complete(collection)
-        }
-    return future
 }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflow.kt
@@ -166,6 +166,5 @@ internal data class CompleteWithdrawalWorkflowParams(
     val address: String,
     val starkKey: String,
     val assetType: BigInteger,
-//    val amount: BigInteger,
     val isRegistered: Boolean = false,
 )

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflow.kt
@@ -9,13 +9,12 @@ import com.immutable.sdk.api.model.GetSignableRegistrationResponse
 import com.immutable.sdk.contracts.Core_sol_Core
 import com.immutable.sdk.contracts.Registration_sol_Registration
 import com.immutable.sdk.model.*
-import com.immutable.sdk.workflows.withdrawal.completeEthWithdrawal
+import com.immutable.sdk.workflows.withdrawal.completeFungibleTokenWithdrawal
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.methods.response.EthSendTransaction
 import org.web3j.protocol.http.HttpService
 import org.web3j.tx.ClientTransactionManager
 import org.web3j.tx.gas.DefaultGasProvider
-import org.web3j.utils.Convert
 import java.math.BigInteger
 import java.util.concurrent.CompletableFuture
 
@@ -29,10 +28,8 @@ internal fun completeWithdrawal(
     usersApi: UsersApi,
     encodingApi: EncodingApi,
 ): CompletableFuture<String> = when (token) {
-    is EthAsset ->
-        completeEthWithdrawal(base, nodeUrl, token, signer, starkPublicKey, usersApi, encodingApi)
-    is Erc20Asset -> CompletableFuture.failedFuture(UnsupportedOperationException())
     is Erc721Asset -> CompletableFuture.failedFuture(UnsupportedOperationException())
+    else -> completeFungibleTokenWithdrawal(base, nodeUrl, token, signer, starkPublicKey, usersApi, encodingApi)
 }
 
 /**
@@ -51,12 +48,6 @@ internal fun prepareCompleteWithdrawal(
     usersApi: UsersApi,
     encodingApi: EncodingApi
 ): CompletableFuture<CompleteWithdrawalWorkflowParams> {
-    val amount = when (token) {
-        is EthAsset -> Convert.toWei(token.quantity, Convert.Unit.ETHER).toBigInteger()
-        is Erc20Asset -> token.formatQuantity().toBigInteger()
-        is Erc721Asset -> BigInteger.ONE
-    }
-
     return signer.getAddress()
         .thenCompose { address ->
             encodeAsset(token, encodingApi).thenApply { encodeAssetResponse ->
@@ -65,7 +56,6 @@ internal fun prepareCompleteWithdrawal(
                     address = address,
                     starkKey = starkPublicKey,
                     assetType = encodeAssetResponse.assetType.toBigInteger(),
-                    amount = amount
                 )
             }
         }
@@ -176,6 +166,6 @@ internal data class CompleteWithdrawalWorkflowParams(
     val address: String,
     val starkKey: String,
     val assetType: BigInteger,
-    val amount: BigInteger,
+//    val amount: BigInteger,
     val isRegistered: Boolean = false,
 )

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/CompleteEthWithdrawalWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/CompleteEthWithdrawalWorkflow.kt
@@ -10,16 +10,16 @@ import com.immutable.sdk.contracts.Core_sol_Core
 import com.immutable.sdk.contracts.Registration_sol_Registration
 import com.immutable.sdk.extensions.hexRemovePrefix
 import com.immutable.sdk.extensions.hexToByteArray
-import com.immutable.sdk.model.EthAsset
+import com.immutable.sdk.model.AssetModel
 import com.immutable.sdk.workflows.executeCompleteWithdrawal
 import com.immutable.sdk.workflows.prepareCompleteWithdrawal
 import java.util.concurrent.CompletableFuture
 
 @Suppress("LongParameterList", "LongMethod")
-internal fun completeEthWithdrawal(
+internal fun completeFungibleTokenWithdrawal(
     base: ImmutableXBase,
     nodeUrl: String,
-    token: EthAsset,
+    token: AssetModel,
     signer: Signer,
     starkPublicKey: String,
     usersApi: UsersApi,

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/ImxTimestampTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/ImxTimestampTest.kt
@@ -4,6 +4,7 @@ import com.immutable.sdk.Signer
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import junit.framework.TestCase.assertEquals
 import org.junit.After
@@ -14,10 +15,12 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.util.concurrent.CompletableFuture
 
-private const val SIGNATURE = "0xc5b53280e17b53d130eed7f00fc4270c29910fc30445af60dbb6abd82dc98f5923fb2fa2" +
-    "a8940c1d6d871c984f19954d25d913857e798d0c8f3fe98b57e7bcb61c"
-private const val SERIALIZED_SIGNATURE = "0xc5b53280e17b53d130eed7f00fc4270c29910fc30445af60dbb6abd82dc98f5923fb2fa2" +
-    "a8940c1d6d871c984f19954d25d913857e798d0c8f3fe98b57e7bcb601"
+private const val SIGNATURE =
+    "0xc5b53280e17b53d130eed7f00fc4270c29910fc30445af60dbb6abd82dc98f5923fb2fa2" +
+        "a8940c1d6d871c984f19954d25d913857e798d0c8f3fe98b57e7bcb61c"
+private const val SERIALIZED_SIGNATURE =
+    "0xc5b53280e17b53d130eed7f00fc4270c29910fc30445af60dbb6abd82dc98f5923fb2fa2" +
+        "a8940c1d6d871c984f19954d25d913857e798d0c8f3fe98b57e7bcb601"
 
 class ImxTimestampTest {
     @MockK
@@ -38,9 +41,25 @@ class ImxTimestampTest {
     @Test
     fun testImxTimestampRequest() {
         every { signer.signMessage("1453552496") } returns CompletableFuture.completedFuture(SIGNATURE)
+
         val future = imxTimestampRequest(signer, clock) { timestamp ->
             CompletableFuture.completedFuture(timestamp)
         }.get()
+
+        assertEquals("1453552496", future.timestamp)
+        assertEquals(SERIALIZED_SIGNATURE, future.signature)
+    }
+
+    @Test
+    fun testImxTimestampRequest2() {
+        mockkStatic(Clock::class)
+        every { Clock.systemUTC() } returns clock
+        every { signer.signMessage("1453552496") } returns CompletableFuture.completedFuture(SIGNATURE)
+
+        val future = imxTimestampRequest(signer) { timestamp ->
+            CompletableFuture.completedFuture(timestamp)
+        }.get()
+
         assertEquals("1453552496", future.timestamp)
         assertEquals(SERIALIZED_SIGNATURE, future.signature)
     }


### PR DESCRIPTION
* Withdraw ERC20 -  Refactored withdraw ETH workflow so that it can be used for withdrawing ERC20
* Removed unused 'amount' from complete withdrawal workflow functions
* Refactored ImxTimestamp and added another unit test case
* Refactored cancel workflow