### PR TITLE
feat: allow users to set gas for functions that interact with contracts

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/RegisterWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/RegisterWorkflow.kt
@@ -13,7 +13,7 @@ import org.openapitools.client.infrastructure.ClientException
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.http.HttpService
 import org.web3j.tx.ClientTransactionManager
-import org.web3j.tx.gas.DefaultGasProvider
+import org.web3j.tx.gas.StaticGasProvider
 import java.net.HttpURLConnection
 import java.util.concurrent.CompletableFuture
 
@@ -136,7 +136,8 @@ internal fun isRegisteredOnChain(
     base: ImmutableXBase,
     nodeUrl: String,
     signer: Signer,
-    api: UsersApi
+    api: UsersApi,
+    gasProvider: StaticGasProvider
 ): CompletableFuture<Boolean> {
     val future = CompletableFuture<Boolean>()
 
@@ -152,7 +153,7 @@ internal fun isRegisteredOnChain(
                 ImmutableConfig.getRegistrationContractAddress(base),
                 web3j,
                 ClientTransactionManager(web3j, address),
-                DefaultGasProvider()
+                gasProvider
             )
             contract.isRegistered(starkPublicKey.hexRemovePrefix().toBigInteger(HEX_RADIX))
                 .sendAsync()

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/Workflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/Workflow.kt
@@ -8,7 +8,7 @@ import org.web3j.crypto.RawTransaction
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.methods.response.EthSendTransaction
 import org.web3j.tx.Contract
-import org.web3j.tx.gas.DefaultGasProvider
+import org.web3j.tx.gas.StaticGasProvider
 import java.math.BigInteger
 import java.util.concurrent.CompletableFuture
 
@@ -48,12 +48,12 @@ internal fun sendTransaction(
     data: String,
     signer: Signer,
     web3j: Web3j,
+    gasProvider: StaticGasProvider
 ): CompletableFuture<EthSendTransaction> {
     val future = CompletableFuture<EthSendTransaction>()
     CompletableFuture.runAsync {
         try {
             val address = signer.getAddress().get()
-            val gasProvider = DefaultGasProvider()
 
             val rawTransaction = RawTransaction.createTransaction(
                 web3j.getNonce(address),

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositErc20Workflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositErc20Workflow.kt
@@ -21,7 +21,7 @@ import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.methods.response.EthSendTransaction
 import org.web3j.protocol.http.HttpService
 import org.web3j.tx.ClientTransactionManager
-import org.web3j.tx.gas.DefaultGasProvider
+import org.web3j.tx.gas.StaticGasProvider
 import java.util.concurrent.CompletableFuture
 
 @Suppress("LongParameterList", "LongMethod")
@@ -33,13 +33,16 @@ internal fun depositErc20(
     depositsApi: DepositsApi,
     usersApi: UsersApi,
     encodingApi: EncodingApi,
+    gasProvider: StaticGasProvider,
 ): CompletableFuture<String> {
     val future = CompletableFuture<String>()
 
     val web3j = Web3j.build(HttpService(nodeUrl))
 
-    approveErc20Token(base, token, web3j, signer)
-        .thenCompose { prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi) }
+    approveErc20Token(base, token, web3j, signer, gasProvider)
+        .thenCompose {
+            prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi, gasProvider)
+        }
         .thenCompose { params ->
             executeDeposit(
                 base,
@@ -66,7 +69,8 @@ internal fun depositErc20(
                         params.amount
                     ).encodeFunctionCall()
                 },
-                usersApi
+                usersApi,
+                gasProvider
             )
         }
         .whenComplete { response, throwable ->
@@ -84,14 +88,15 @@ private fun approveErc20Token(
     base: ImmutableXBase,
     token: Erc20Asset,
     web3j: Web3j,
-    signer: Signer
+    signer: Signer,
+    gasProvider: StaticGasProvider
 ): CompletableFuture<EthSendTransaction> = signer.getAddress()
     .thenCompose { address ->
         val contract = IERC20_sol_IERC20.load(
             token.tokenAddress,
             web3j,
             ClientTransactionManager(web3j, address),
-            DefaultGasProvider()
+            gasProvider
         )
 
         sendTransaction(
@@ -102,6 +107,7 @@ private fun approveErc20Token(
                 token.formatQuantity().toBigInteger()
             ).encodeFunctionCall(),
             signer = signer,
-            web3j = web3j
+            web3j = web3j,
+            gasProvider = gasProvider
         )
     }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositErc20Workflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositErc20Workflow.kt
@@ -34,12 +34,8 @@ internal fun depositErc20(
     usersApi: UsersApi,
     encodingApi: EncodingApi,
     gasProvider: StaticGasProvider,
-): CompletableFuture<String> {
-    val future = CompletableFuture<String>()
-
-    val web3j = Web3j.build(HttpService(nodeUrl))
-
-    approveErc20Token(base, token, web3j, signer, gasProvider)
+): CompletableFuture<String> =
+    approveErc20Token(base, token, Web3j.build(HttpService(nodeUrl)), signer, gasProvider)
         .thenCompose {
             prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi, gasProvider)
         }
@@ -73,13 +69,7 @@ internal fun depositErc20(
                 gasProvider
             )
         }
-        .whenComplete { response, throwable ->
-            if (throwable != null) future.completeExceptionally(throwable)
-            else future.complete(response.transactionHash)
-        }
-
-    return future
-}
+        .thenApply { it.transactionHash }
 
 /**
  * Approve whether an amount of token from an account can be spent by a third-party account

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositErc721Workflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositErc721Workflow.kt
@@ -36,11 +36,9 @@ internal fun depositErc721(
     encodingApi: EncodingApi,
     gasProvider: StaticGasProvider,
 ): CompletableFuture<String> {
-    val future = CompletableFuture<String>()
-
     val web3j = Web3j.build(HttpService(nodeUrl))
 
-    prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi, gasProvider)
+    return prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi, gasProvider)
         .thenCompose { params ->
             approveErc721Token(
                 token,
@@ -100,12 +98,7 @@ internal fun depositErc721(
                 gasProvider = gasProvider
             )
         }
-        .whenComplete { response, throwable ->
-            if (throwable != null) future.completeExceptionally(throwable)
-            else future.complete(response.transactionHash)
-        }
-
-    return future
+        .thenApply { it.transactionHash }
 }
 
 /**

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositEthWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositEthWorkflow.kt
@@ -26,9 +26,7 @@ internal fun depositEth(
     usersApi: UsersApi,
     encodingApi: EncodingApi,
     gasProvider: StaticGasProvider
-): CompletableFuture<String> {
-    val future = CompletableFuture<String>()
-
+): CompletableFuture<String> =
     prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi, gasProvider)
         .thenCompose { params ->
             executeDeposit(
@@ -58,10 +56,4 @@ internal fun depositEth(
                 gasProvider
             )
         }
-        .whenComplete { response, throwable ->
-            if (throwable != null) future.completeExceptionally(throwable)
-            else future.complete(response.transactionHash)
-        }
-
-    return future
-}
+        .thenApply { it.transactionHash }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositEthWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/deposit/DepositEthWorkflow.kt
@@ -13,6 +13,7 @@ import com.immutable.sdk.extensions.hexToByteArray
 import com.immutable.sdk.model.EthAsset
 import com.immutable.sdk.workflows.executeDeposit
 import com.immutable.sdk.workflows.prepareDeposit
+import org.web3j.tx.gas.StaticGasProvider
 import java.util.concurrent.CompletableFuture
 
 @Suppress("LongParameterList", "LongMethod")
@@ -24,10 +25,11 @@ internal fun depositEth(
     depositsApi: DepositsApi,
     usersApi: UsersApi,
     encodingApi: EncodingApi,
+    gasProvider: StaticGasProvider
 ): CompletableFuture<String> {
     val future = CompletableFuture<String>()
 
-    prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi)
+    prepareDeposit(base, nodeUrl, token, signer, depositsApi, usersApi, encodingApi, gasProvider)
         .thenCompose { params ->
             executeDeposit(
                 base,
@@ -52,7 +54,8 @@ internal fun depositEth(
                         params.vaultId
                     ).encodeFunctionCall()
                 },
-                usersApi
+                usersApi,
+                gasProvider
             )
         }
         .whenComplete { response, throwable ->

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/CompleteErc721WithdrawalWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/CompleteErc721WithdrawalWorkflow.kt
@@ -17,6 +17,7 @@ import com.immutable.sdk.model.Erc721Asset
 import com.immutable.sdk.workflows.executeCompleteWithdrawal
 import com.immutable.sdk.workflows.prepareCompleteWithdrawal
 import org.openapitools.client.infrastructure.ClientException
+import org.web3j.tx.gas.StaticGasProvider
 import java.net.HttpURLConnection
 import java.util.concurrent.CompletableFuture
 
@@ -31,7 +32,8 @@ internal fun completeErc721Withdrawal(
     starkPublicKey: String,
     usersApi: UsersApi,
     encodingApi: EncodingApi,
-    mintsApi: MintsApi
+    mintsApi: MintsApi,
+    gasProvider: StaticGasProvider
 ): CompletableFuture<String> = getMintableTokenDetails(token, mintsApi)
     .thenCompose { assetToken ->
         prepareCompleteWithdrawal(
@@ -41,7 +43,8 @@ internal fun completeErc721Withdrawal(
             signer,
             starkPublicKey,
             usersApi,
-            encodingApi
+            encodingApi,
+            gasProvider
         )
     }
     .thenCompose { params ->
@@ -83,7 +86,8 @@ internal fun completeErc721Withdrawal(
                     token.tokenId.toBigInteger()
                 ).encodeFunctionCall()
             },
-            usersApi
+            usersApi,
+            gasProvider
         )
     }
     .thenApply { it.transactionHash }

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/CompleteFungibleTokenWithdrawalWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/withdrawal/CompleteFungibleTokenWithdrawalWorkflow.kt
@@ -13,6 +13,7 @@ import com.immutable.sdk.extensions.hexToByteArray
 import com.immutable.sdk.model.AssetModel
 import com.immutable.sdk.workflows.executeCompleteWithdrawal
 import com.immutable.sdk.workflows.prepareCompleteWithdrawal
+import org.web3j.tx.gas.StaticGasProvider
 import java.util.concurrent.CompletableFuture
 
 @Suppress("LongParameterList", "LongMethod")
@@ -24,6 +25,7 @@ internal fun completeFungibleTokenWithdrawal(
     starkPublicKey: String,
     usersApi: UsersApi,
     encodingApi: EncodingApi,
+    gasProvider: StaticGasProvider,
 ): CompletableFuture<String> = signer.getAddress()
     .thenCompose {
         prepareCompleteWithdrawal(
@@ -33,7 +35,8 @@ internal fun completeFungibleTokenWithdrawal(
             signer,
             starkPublicKey,
             usersApi,
-            encodingApi
+            encodingApi,
+            gasProvider
         )
     }
     .thenCompose { params ->
@@ -58,7 +61,8 @@ internal fun completeFungibleTokenWithdrawal(
                     params.assetType,
                 ).encodeFunctionCall()
             },
-            usersApi
+            usersApi,
+            gasProvider
         )
     }
     .thenApply { it.transactionHash }

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/DepositWorkflowTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/DepositWorkflowTest.kt
@@ -26,6 +26,7 @@ import org.web3j.protocol.core.methods.response.EthSendTransaction
 import org.web3j.protocol.core.methods.response.TransactionReceipt
 import org.web3j.protocol.http.HttpService
 import org.web3j.tx.TransactionManager
+import org.web3j.tx.gas.DefaultGasProvider
 import java.io.IOException
 import java.math.BigInteger
 import java.util.concurrent.CompletableFuture
@@ -95,6 +96,9 @@ class DepositWorkflowTest {
 
     @MockK
     private lateinit var ethSendTransaction: EthSendTransaction
+
+    @MockK
+    private lateinit var gasProvider: DefaultGasProvider
 
     private lateinit var addressFuture: CompletableFuture<String>
     private lateinit var signedTransactionFuture: CompletableFuture<String>
@@ -177,6 +181,9 @@ class DepositWorkflowTest {
         } returns erc721Contract
         every { erc721Contract.approve(any(), any()) } returns txRemoteFunctionCall
         every { erc721Contract.contractAddress } returns ERC721_CONTRACT_ADDRESS
+
+        every { gasProvider.gasPrice } returns DefaultGasProvider.GAS_PRICE
+        every { gasProvider.getGasLimit(any()) } returns DefaultGasProvider.GAS_LIMIT
     }
 
     @After
@@ -185,11 +192,7 @@ class DepositWorkflowTest {
     }
 
     private fun createDepositFuture(token: AssetModel) = deposit(
-        base = ImmutableXBase.Sandbox,
-        nodeUrl = NODE_URL,
-        token,
-        signer,
-        depositsApi, usersApi, encodingApi
+        ImmutableXBase.Sandbox, NODE_URL, token, signer, depositsApi, usersApi, encodingApi, gasProvider
     )
 
     private fun <T> remoteFunctionCall(value: T) = RemoteFunctionCall(function) { value }

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflowTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/workflows/WithdrawalWorkflowTest.kt
@@ -28,6 +28,7 @@ import org.web3j.protocol.core.methods.response.EthSendTransaction
 import org.web3j.protocol.core.methods.response.TransactionReceipt
 import org.web3j.protocol.http.HttpService
 import org.web3j.tx.TransactionManager
+import org.web3j.tx.gas.DefaultGasProvider
 import java.io.IOException
 import java.math.BigInteger
 import java.net.HttpURLConnection
@@ -93,6 +94,9 @@ class WithdrawalWorkflowTest {
     @MockK
     private lateinit var mintableTokenDetails: MintableTokenDetails
 
+    @MockK
+    private lateinit var gasProvider: DefaultGasProvider
+
     private lateinit var addressFuture: CompletableFuture<String>
     private lateinit var signedTransactionFuture: CompletableFuture<String>
 
@@ -155,6 +159,9 @@ class WithdrawalWorkflowTest {
         every { coreContract.contractAddress } returns CORE_CONTRACT_ADDRESS
 
         every { mintableTokenDetails.blueprint } returns BLUEPRINT
+
+        every { gasProvider.gasPrice } returns DefaultGasProvider.GAS_PRICE
+        every { gasProvider.getGasLimit(any()) } returns DefaultGasProvider.GAS_LIMIT
     }
 
     @After
@@ -170,7 +177,8 @@ class WithdrawalWorkflowTest {
         STARK_KEY,
         usersApi,
         encodingApi,
-        mintsApi
+        mintsApi,
+        gasProvider
     )
 
     private fun <T> remoteFunctionCall(value: T) = RemoteFunctionCall(function) { value }


### PR DESCRIPTION
- Allow users to set gas for functions that interact with contracts (`deposit`, `withdraw` and `isRegisteredOnChain`) since the gas is automatically set by the SDK (using `DefaultGasProvider` might be too low).
- Refactor deposit workflow so there is no need to create another `CompletableFuture` to wrap the chain of `CompletableFuture`s