### PR TITLE
fix: register and deposit ERC721

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/DepositWorkflow.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/workflows/DepositWorkflow.kt
@@ -145,7 +145,7 @@ internal fun executeDeposit(
 }
 
 @Suppress("LongParameterList")
-internal fun <C : Contract> executeRegisterAndDepositToken(
+private fun <C : Contract> executeRegisterAndDepositToken(
     web3j: Web3j,
     signer: Signer,
     params: DepositWorkflowParams,


### PR DESCRIPTION
# Summary
Fixed "Register and Deposit ERC721" workflow.

# Why the changes
The proxy registration contract method registerAndDepositNft currently fails ownership check in the ERC-721 transfer method. This workaround performs the register and deposit method calls separately.

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - `N/A`