### PR TITLE
feat: generate legacy key pair

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
@@ -134,7 +134,7 @@ object StarkKey {
      * @returns the private key as a hex string
      */
     @Suppress("MagicNumber")
-    fun generateLegacyKeyPair(seed: String, ethereumAddress: String): String {
+    fun generateLegacyStarkPrivateKey(seed: String, ethereumAddress: String): String {
         val bytes = seed.hexToByteArray()
         val s = bytes.copyOfRange(32, 64).toNoPrefixHexString()
         return getKeyPairFromPath(s, getAccountPath(ethereumAddress))

--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/crypto/StarkKey.kt
@@ -2,16 +2,23 @@ package com.immutable.sdk.crypto
 
 import com.google.common.annotations.VisibleForTesting
 import com.immutable.sdk.Constants
+import com.immutable.sdk.Constants.HEX_RADIX
 import com.immutable.sdk.extensions.*
 import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.crypto.signers.ECDSASigner
 import org.bouncycastle.crypto.signers.HMacDSAKCalculator
 import org.bouncycastle.util.BigIntegers
+import org.web3j.crypto.Bip32ECKeyPair
 import org.web3j.crypto.ECDSASignature
 import org.web3j.crypto.ECKeyPair
 import java.math.BigInteger
 import java.security.MessageDigest
 
+private const val LAYER = "starkex"
+private const val APPLICATION = "immutablex"
+private const val ACCOUNT_PATH = "m/2645'/%d'/%d'/%d'/%d'/1"
+
+private const val HARDENED_BIT = 0x80000000.toInt()
 private val ORDER = BigInteger(
     "0800000000000010ffffffffffffffffb781126dcae7b2321e66a241adc64d2f",
     Constants.HEX_RADIX,
@@ -38,6 +45,43 @@ object StarkKey {
     }
 
     /**
+     * Grabs the bits from [startFromEnd] to [endFromEnd] in [hex] amd returns
+     * the integer representation of it.
+     *
+     * If [endFromEnd] is null, this function will grab all the bits from [startFromEnd] to the last bit.
+     */
+    internal fun getIntFromBits(
+        hex: String,
+        startFromEnd: Int,
+        endFromEnd: Int? = null,
+    ): Int {
+        val bin = hex.hexToBinary()
+        val bits = if (endFromEnd == null) {
+            bin.takeLast(startFromEnd)
+        } else {
+            val start = bin.length - startFromEnd
+            val end = bin.length - endFromEnd
+            bin.substring(start, end)
+        }
+        return Integer.parseInt(bits, 2)
+    }
+
+    /**
+     * @return StarkEx and ImmutableX account path from the [ethereumAddress]
+     */
+    @Suppress("MagicNumber")
+    @VisibleForTesting
+    internal fun getAccountPath(ethereumAddress: String): String {
+        val layerHash = hashSha256(LAYER.toByteArray())
+        val applicationHash = hashSha256(APPLICATION.toByteArray())
+        val layerInt = getIntFromBits(layerHash, startFromEnd = 31)
+        val applicationInt = getIntFromBits(applicationHash, startFromEnd = 31)
+        val ethAddressInt1 = getIntFromBits(ethereumAddress.substring(2), 31)
+        val ethAddressInt2 = getIntFromBits(ethereumAddress.substring(2), 62, 31)
+        return String.format(ACCOUNT_PATH, layerInt, applicationInt, ethAddressInt1, ethAddressInt2)
+    }
+
+    /**
      * Combines the [key] and [index] and SHA-256 hash them
      */
     private fun hashKeyWithIndex(key: String, index: Int): BigInteger {
@@ -57,6 +101,43 @@ object StarkKey {
             i++
         }
         return key.mod(ORDER).toString(Constants.HEX_RADIX)
+    }
+
+    /**
+     * Generates the Stark key pair from the [seed] and [path]
+     */
+    private fun getKeyPairFromPath(seed: String, path: String): String {
+        val master =
+            Bip32ECKeyPair.generateKeyPair(BigInteger(seed, Constants.HEX_RADIX).toByteArray())
+        val pathArray =
+            path.split("/") // Example: "m/2645'/579218131'/211006541'/9971226311'/947333111'/1"
+        val p = pathArray
+            .subList(1, pathArray.size) // Ignore the first one
+            .map {
+                val isHardened = it.endsWith("'")
+                it
+                    .replace("'", "") // Remove hardened notation
+                    .toInt() // Convert string to int
+                    .run {
+                        if (isHardened) this or HARDENED_BIT else this
+                    }
+            }.toIntArray()
+        val gk = grindKey(
+            Bip32ECKeyPair.deriveKeyPair(master, p)
+                .privateKeyBytes33.drop(1).toHexString()
+        )
+        return gk.sanitizeBytes()
+    }
+
+    /**
+     * Generates a deterministic Stark private key from the provided signer.
+     * @returns the private key as a hex string
+     */
+    @Suppress("MagicNumber")
+    fun generateLegacyKeyPair(seed: String, ethereumAddress: String): String {
+        val bytes = seed.hexToByteArray()
+        val s = bytes.copyOfRange(32, 64).toNoPrefixHexString()
+        return getKeyPairFromPath(s, getAccountPath(ethereumAddress))
     }
 
     /**
@@ -89,7 +170,8 @@ object StarkKey {
      */
     fun generateStarkPrivateKey(): String {
         val privateKey = StarkCurve.generatePrivateKey()
-        return StarkCurve.getKeyPair(grindKey(privateKey.toHexString())).privateKey.toByteArray().toNoPrefixHexString()
+        return StarkCurve.getKeyPair(grindKey(privateKey.toHexString())).privateKey.toByteArray()
+            .toNoPrefixHexString()
     }
 
     /**

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
@@ -107,7 +107,7 @@ class StarkKeyTest {
 
     @Test
     fun testGenerateLegacyKeyPair() {
-        val pk = StarkKey.generateLegacyKeyPair(
+        val pk = StarkKey.generateLegacyStarkPrivateKey(
             "0xe834136cc3206a8f80acd81922d80b377ca769dc973d83ee2bd8bed4b7cdc3565f2a3aded8de5c93f85" +
                 "327d5c1fb535959bdc3068318875b95788b074f3ab2931c",
             "0x2cD7944D8398017d0D142Ea2Ec483bc230f01A84"

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
@@ -1,16 +1,41 @@
 package com.immutable.sdk.crypto
 
 import com.immutable.sdk.Constants
+import com.immutable.sdk.Signer
 import io.mockk.*
+import io.mockk.impl.annotations.MockK
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 import org.web3j.crypto.ECKeyPair
 import java.math.BigInteger
 
 class StarkKeyTest {
+    @MockK
+    lateinit var signer: Signer
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun testGetAccountPath() {
+        val path = StarkKey.getAccountPath("0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f")
+        assertEquals("m/2645'/579218131'/211006541'/1534045311'/1431804530'/1", path)
+    }
+
+    @Test
+    fun testGetIntFromBits() {
+        // binary representation: 00010010001101001010011001001001101111111101100001001111111101000101001000100010
+        val hex = "1234a649bfd84ff45222"
+        assertEquals(34, StarkKey.getIntFromBits(hex, 9)) // 000100010
+        assertEquals(1_024_657, StarkKey.getIntFromBits(hex, 25, 5)) // 11111010001010010001
+    }
+
     @Test
     fun testHashSha256Update() {
         assertEquals(
@@ -78,5 +103,15 @@ class StarkKeyTest {
             StarkCurve.generatePrivateKey()
             StarkCurve.getKeyPair(any())
         }
+    }
+
+    @Test
+    fun testGenerateLegacyKeyPair() {
+        val pk = StarkKey.generateLegacyKeyPair(
+            "0xe834136cc3206a8f80acd81922d80b377ca769dc973d83ee2bd8bed4b7cdc3565f2a3aded8de5c93f85" +
+                "327d5c1fb535959bdc3068318875b95788b074f3ab2931c",
+            "0x2cD7944D8398017d0D142Ea2Ec483bc230f01A84"
+        )
+        assertEquals("0512653c071aa6fb61615354cb850c1d6c122635c08329ce3b5c1f23ec844d19", pk)
     }
 }


### PR DESCRIPTION
# Summary
Add method to deterministically generate Stark private key

# Why the changes
Adding this method to ensure that existing customers that want to generate their stark key deterministically, there is a way to do that by passing in the previously used seed.

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - `N/A`