### PR TITLE
feat: update generateLegacyStarkPrivateKey to take in a signer

### DIFF
--- a/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Constants.kt
+++ b/imx-core-sdk-kotlin-jvm/src/main/kotlin/com/immutable/sdk/Constants.kt
@@ -1,6 +1,8 @@
 package com.immutable.sdk
 
 internal object Constants {
+    const val STARK_MESSAGE =
+        "Only sign this request if you’ve initiated an action with Immutable X."
     const val STARK_KEY_PUBLIC_BYTE_LENGTH = 32
 
     const val HEX_PREFIX = "0x"

--- a/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
+++ b/imx-core-sdk-kotlin-jvm/src/test/kotlin/com/immutable/sdk/crypto/StarkKeyTest.kt
@@ -12,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import org.web3j.crypto.ECKeyPair
 import java.math.BigInteger
+import java.util.concurrent.CompletableFuture
 
 class StarkKeyTest {
     @MockK
@@ -107,11 +108,15 @@ class StarkKeyTest {
 
     @Test
     fun testGenerateLegacyKeyPair() {
-        val pk = StarkKey.generateLegacyStarkPrivateKey(
-            "0xe834136cc3206a8f80acd81922d80b377ca769dc973d83ee2bd8bed4b7cdc3565f2a3aded8de5c93f85" +
-                "327d5c1fb535959bdc3068318875b95788b074f3ab2931c",
-            "0x2cD7944D8398017d0D142Ea2Ec483bc230f01A84"
-        )
+        every { signer.getAddress() } returns
+            CompletableFuture.completedFuture("0x2cD7944D8398017d0D142Ea2Ec483bc230f01A84")
+        every { signer.signMessage(any()) } returns
+            CompletableFuture.completedFuture(
+                "0xe834136cc3206a8f80acd81922d80b377ca769dc973d83ee2bd8bed4b7cdc3565f2a3aded8de5c93f85" +
+                    "327d5c1fb535959bdc3068318875b95788b074f3ab2931c"
+            )
+
+        val pk = StarkKey.generateLegacyStarkPrivateKey(signer).get()
         assertEquals("0512653c071aa6fb61615354cb850c1d6c122635c08329ce3b5c1f23ec844d19", pk)
     }
 }


### PR DESCRIPTION
# Summary
Update `generateLegacyStarkPrivateKey` function to take in a `signer` instead of a seed and address.

# Why the changes
To align with the Swift and TS Core SDK.

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - `N/A`