### PR TITLE
[DX-1698] Add section linking to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ See the [developer guides](https://docs.x.immutable.com) for information on buil
 
 See the [API reference documentation](https://docs.x.immutable.com/reference) for more information on our API's.
 
+### Examples
+* **Sample code** - see the [sample](./sample/) folder for examples of key SDK functionality.
+
 ## Installation
 
 1. Add Maven Central to your repositories


### PR DESCRIPTION
# Summary
This adds a section to the README referencing where to find example code in this repo

Jira: https://immutable.atlassian.net/browse/DX-1698

# Why the changes
To make it easier for developers using this SDK to find examples

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [x] N/A