### PR TITLE
docs: dx-2500, added deprecation banner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @immutable/wallets

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# These owners will be the default owners for everything in the repo.
-*       @immutable/wallets

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 ---
 
+# 🚨 This library is no longer maintained 🚨
+
+If you're building apps with Immutable, please use [Immutable's Unified SDK](https://github.com/immutable/ts-immutable-sdk)
+
 # Immutable X Core SDK Kotlin/JVM
 
 The Immutable X Core SDK Kotlin/JVM provides convenient access to the Immutable API's for applications written on the Immutable X platform.
@@ -19,23 +23,29 @@ See the [developer guides](https://docs.x.immutable.com) for information on buil
 See the [API reference documentation](https://docs.x.immutable.com/reference) for more information on our API's.
 
 ### Examples
+
 * **Sample code** - see the [sample](./sample/) folder for examples of key SDK functionality.
 
 ## Installation
 
 1. Add Maven Central to your repositories
+
 ```gradle
 repositories {
     mavenCentral()
 }
 ```
+
 2. Add dependency to your app `build.gradle` file
+
 ```gradle
 dependencies {
     implementation 'com.immutable.sdk:imx-core-sdk-kotlin-jvm:$version'
 }
 ```
+
 3. Set the correct environment (defaults to Production)
+
 ```kt
 val immutableX = ImmutableX(ImmutableXBase.Sandbox)
 ```
@@ -55,6 +65,7 @@ val immutableX = ImmutableX(ImmutableXBase.Sandbox)
 The Core SDK includes functions that interact with the Immutable X APIs.
 
 e.g. Get a list of collections ordered by name in ascending order
+
 ```kt
 val response = immutableX.listCollections(
     pageSize = 20,
@@ -62,7 +73,9 @@ val response = immutableX.listCollections(
     direction = "asc"
 )
 ```
+
 OR
+
 ```kt
 val response = immutableX.collectionsApi.listCollections(
     pageSize = 20,
@@ -70,6 +83,7 @@ val response = immutableX.collectionsApi.listCollections(
     direction = "asc"
 )
 ```
+
 View the [OpenAPI spec](openapi.json) for a full list of API requests available in the Core SDK.
 
 ## Workflow Functions
@@ -125,8 +139,11 @@ class L1Signer(private val credentials: Credentials) : Signer {
 #### L2 StarkSigner
 
 Use `StarkKey.generateStarkPrivateKey()` to create an instance of `StandardStarkSigner`, an implementation of `StarkSigner`.
+
 #### 🚨🚨🚨 Warning 🚨🚨🚨
+>
 > You will have to persist the Stark private key. The key is [randomly generated](/src/utils/stark/starkCurve.ts#L99) so **_cannot_** be deterministically re-generated.
+
 ```kt
 val starkPrivateKey = StarkKey.generateStarkPrivateKey()
 val starkSigner = StandardStarkSigner(starkPrivateKey)
@@ -140,7 +157,7 @@ Parts of the Core SDK are automagically generated.
 
 We use OpenAPI (formally known as Swagger) to auto-generate the API clients that connect to the public APIs.
 
-The OpenAPI spec is retrieved from https://api.x.immutable.com/openapi and also saved in the repo [here](openapi.json).
+The OpenAPI spec is retrieved from <https://api.x.immutable.com/openapi> and also saved in the repo [here](openapi.json).
 
 When updating the `org.openapi.generator` plugin ensure that any custom templates are appropriately modified or removed. These can be found in the .openapi-generator/templates directory.
 
@@ -149,9 +166,11 @@ The generation always happens on preBuild so triggering a project build will reg
 ## Wrapping CompletableFuture
 
 ### RxJava
+
 Rx provides a `fromFuture` method that will trigger `future.get()` which is a blocking call so it must be moved off the main thread.
 
 Disposing the resulting observable will not cancel the future so that needs to be done manually using `doOnDispose`.
+
 ```kt
 val future = immutableX.cancelOrder(orderId)
 Observable.fromFuture(future)
@@ -161,14 +180,17 @@ Observable.fromFuture(future)
 ```
 
 ### Coroutines
+
 The Kotlin team has a set of packages for jdk8 that provide an easy extension for using CompletableFuture.
 
 First add this import to your project:
+
 ```kt
 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutines_version"
 ```
 
 Then simply call `.await()` on the workflow `CompletableFuture` and wrap it with a try/catch to handle any exceptions.
+
 ```kt
 launch(Dispatchers.Default) {
     try {
@@ -183,11 +205,11 @@ launch(Dispatchers.Default) {
 
 The following headings should be used as appropriate
 
-- Added
-- Changed
-- Deprecated
-- Removed
-- Fixed
+* Added
+* Changed
+* Deprecated
+* Removed
+* Fixed
 
 What follows is an example with all the change headings, for real world use only use headings when appropriate.
 This goes at the top of the CHANGELOG.md above the most recent release.
@@ -230,11 +252,11 @@ version: 0.1.0
 
 If you would like to contribute, please read the following:
 
-- We use the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification) when writing our commit messages. Why use Conventional Commits? Read [here](https://www.conventionalcommits.org/en/v1.0.0/#why-use-conventional-commits).
+* We use the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification) when writing our commit messages. Why use Conventional Commits? Read [here](https://www.conventionalcommits.org/en/v1.0.0/#why-use-conventional-commits).
 
 ## Maintainers
 
-- [How to release](./RELEASE.md)
+* [How to release](./RELEASE.md)
 
 ## Getting Help
 
@@ -259,4 +281,5 @@ You can also apply for marketing support for your project. Or, if you need help 
 [Contact support](https://support.immutable.com/hc/en-us/requests/new)
 
 ## License
+
 ImmutableX Core SDK Kotlin/JVM repository is distributed under the terms of the [Apache License (Version 2.0)](LICENSE).


### PR DESCRIPTION
# Summary

* Update CODEOWNERS
* Add deprecation banner

# Why the changes

This SDK is being deprecated in favour of Unified SDK.

# Things worth calling out
no code changes

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] Updated doc type 1 PR (SDK references): <Link>
    - [ ] Updated doc type 2 PR (Code samples & guides): <Link>