### PR TITLE
chore: Update releaseGithubPackage.yml

### DIFF
--- a/.github/workflows/releaseGithubPackage.yml
+++ b/.github/workflows/releaseGithubPackage.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   release-github-package:
     runs-on: ubuntu-latest
-    if: contains('["nattb8", "dom-murray"]', github.actor)
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Summary

Remove github actor condition for release workflow

# Why the changes
This package is being deprecated and one more final release needs to go out. 
Removing the condition allows me to publish the final release.

# Things worth calling out
No code changes

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] Updated doc type 1 PR (SDK references): <Link>
    - [ ] Updated doc type 2 PR (Code samples & guides): <Link>